### PR TITLE
Use LivingEntityRendererMixin only on client side

### DIFF
--- a/src/main/java/com/kosmx/emotecraft/mixin/ArmorRendererMixin.java
+++ b/src/main/java/com/kosmx/emotecraft/mixin/ArmorRendererMixin.java
@@ -12,6 +12,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+@Environment(EnvType.CLIENT)
 @Mixin(ArmorFeatureRenderer.class)
 public abstract class ArmorRendererMixin<T extends LivingEntity, M extends BipedEntityModel<T>, A extends BipedEntityModel<T>> extends FeatureRenderer<T, M> {
     public ArmorRendererMixin(FeatureRendererContext<T, M> context){

--- a/src/main/java/com/kosmx/emotecraft/mixin/BipedEntityMixin.java
+++ b/src/main/java/com/kosmx/emotecraft/mixin/BipedEntityMixin.java
@@ -24,6 +24,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.function.Function;
 
+@Environment(EnvType.CLIENT)
 @Mixin(BipedEntityModel.class)
 public abstract class BipedEntityMixin<T extends LivingEntity> extends AnimalModel<T> implements IMutatedBipedModel {
 

--- a/src/main/java/com/kosmx/emotecraft/mixin/EmotePlayerMixin.java
+++ b/src/main/java/com/kosmx/emotecraft/mixin/EmotePlayerMixin.java
@@ -21,6 +21,7 @@ import org.spongepowered.asm.mixin.Mixin;
 
 import javax.annotation.Nullable;
 
+@Environment(EnvType.CLIENT)
 @Mixin(AbstractClientPlayerEntity.class)
 public abstract class EmotePlayerMixin extends PlayerEntity implements EmotePlayerInterface {
 

--- a/src/main/java/com/kosmx/emotecraft/mixin/FeatureRendererMixin.java
+++ b/src/main/java/com/kosmx/emotecraft/mixin/FeatureRendererMixin.java
@@ -5,6 +5,7 @@ import com.kosmx.emotecraft.mixinInterface.IUpperPartHelper;
 import net.minecraft.client.render.entity.feature.FeatureRenderer;
 import org.spongepowered.asm.mixin.Mixin;
 
+@Environment(EnvType.CLIENT)
 @Mixin(FeatureRenderer.class)
 public class FeatureRendererMixin implements IUpperPartHelper {
     private boolean Emotecraft_isUpperPart = true;

--- a/src/main/java/com/kosmx/emotecraft/mixin/HeldItemMixin.java
+++ b/src/main/java/com/kosmx/emotecraft/mixin/HeldItemMixin.java
@@ -21,6 +21,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+@Environment(EnvType.CLIENT)
 @Mixin(HeldItemFeatureRenderer.class)
 public abstract class HeldItemMixin<T extends LivingEntity, M extends EntityModel<T> & ModelWithArms> extends FeatureRenderer<T, M> {
 

--- a/src/main/java/com/kosmx/emotecraft/mixin/KeyEventMixin.java
+++ b/src/main/java/com/kosmx/emotecraft/mixin/KeyEventMixin.java
@@ -8,6 +8,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+@Environment(EnvType.CLIENT)
 @Mixin(KeyBinding.class)
 public class KeyEventMixin {
     @Inject(method = "onKeyPressed", at = @At(value = "HEAD"))

--- a/src/main/java/com/kosmx/emotecraft/mixin/LivingEntityRendererMixin.java
+++ b/src/main/java/com/kosmx/emotecraft/mixin/LivingEntityRendererMixin.java
@@ -18,6 +18,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
+@Environment(EnvType.CLIENT)
 @Mixin(LivingEntityRenderer.class)
 public abstract class LivingEntityRendererMixin<T extends Entity, M extends EntityModel<T>> extends EntityRenderer<T> implements FeatureRendererContext<T, M> {
 

--- a/src/main/java/com/kosmx/emotecraft/mixin/PlayerModelMixin.java
+++ b/src/main/java/com/kosmx/emotecraft/mixin/PlayerModelMixin.java
@@ -19,6 +19,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+@Environment(EnvType.CLIENT)
 @Mixin(PlayerEntityModel.class)
 public class PlayerModelMixin<T extends LivingEntity> extends BipedEntityModel<T> {
     @Shadow

--- a/src/main/java/com/kosmx/emotecraft/mixin/PlayerRendererMixin.java
+++ b/src/main/java/com/kosmx/emotecraft/mixin/PlayerRendererMixin.java
@@ -12,6 +12,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+@Environment(EnvType.CLIENT)
 @Mixin(PlayerEntityRenderer.class)
 public class PlayerRendererMixin {
 

--- a/src/main/java/com/kosmx/emotecraft/mixin/UpperPartMixin.java
+++ b/src/main/java/com/kosmx/emotecraft/mixin/UpperPartMixin.java
@@ -4,6 +4,7 @@ import com.kosmx.emotecraft.mixinInterface.IUpperPartHelper;
 import net.minecraft.client.model.ModelPart;
 import org.spongepowered.asm.mixin.Mixin;
 
+@Environment(EnvType.CLIENT)
 @Mixin(ModelPart.class)
 public class UpperPartMixin implements IUpperPartHelper {
     private boolean Emotecraft_isUpperPart = false;

--- a/src/main/resources/emotecraft.mixins.json
+++ b/src/main/resources/emotecraft.mixins.json
@@ -2,9 +2,7 @@
   "required": true,
   "package": "com.kosmx.emotecraft.mixin",
   "compatibilityLevel": "JAVA_8",
-  "mixins": [
-    "LivingEntityRendererMixin"
-  ],
+  "mixins": [],
   "client": [
     "ArmorRendererMixin",
     "BipedEntityMixin",


### PR DESCRIPTION
LivingEntityRendererMixin was both in the "mixins" and "client" mixins.json sections when it should only be in the latter.

Fixes the server side warning
> [main/WARN]: Error loading class: net/minecraft/class_922 (java.lang.ClassNotFoundException: net/minecraft/class_922)
> [main/WARN]: @Mixin target net.minecraft.class_922 was not found emotecraft.mixins.json:LivingEntityRendererMixin

I'm pretty sure adding all the `@Environment(EnvType.CLIENT)` doesn't actually do anything in this case, but it's still useful as a form of documentation.