### PR TITLE
Added an option to change player speed while playing an emote

### DIFF
--- a/bukkit/src/main/java/io/github/kosmx/emotes/bukkit/BukkitWrapper.java
+++ b/bukkit/src/main/java/io/github/kosmx/emotes/bukkit/BukkitWrapper.java
@@ -104,7 +104,7 @@ public class BukkitWrapper extends JavaPlugin {
                             }
                             player.setWalkSpeed((float) this.config.getDouble("slownessWhilePlaying.speed"));
                             playing.add(player.getUniqueId());
-                        } else {
+                        } else if(data.purpose.equals(PacketTask.STOP)) {
                             if(this.config.getBoolean("slownessWhilePlaying.disableJumping")) {
                                 player.removePotionEffect(PotionEffectType.JUMP);
                             }

--- a/bukkit/src/main/java/io/github/kosmx/emotes/bukkit/EventListener.java
+++ b/bukkit/src/main/java/io/github/kosmx/emotes/bukkit/EventListener.java
@@ -1,15 +1,23 @@
 package io.github.kosmx.emotes.bukkit;
 
 import io.github.kosmx.emotes.common.network.EmotePacket;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerRegisterChannelEvent;
+import org.bukkit.potion.PotionEffectType;
 
 import java.io.IOException;
 
 public class EventListener implements Listener {
+    private final BukkitWrapper plugin;
+
+    public EventListener(BukkitWrapper plugin) {
+        this.plugin = plugin;
+    }
+
     @EventHandler
     public void onPlayerOpenEmoteDiscoveryChannel(PlayerRegisterChannelEvent event){
         BukkitWrapper plugin = BukkitWrapper.getPlugin(BukkitWrapper.class);
@@ -40,8 +48,17 @@ public class EventListener implements Listener {
     }
 
     @EventHandler
-    public void onPlayerLeave(PlayerQuitEvent event){
-        BukkitWrapper.player_database.remove(event.getPlayer().getUniqueId());
+    public void onPlayerLeave(PlayerQuitEvent event) {
+        Player player = event.getPlayer();
+
+        BukkitWrapper.player_database.remove(player.getUniqueId());
+
+        if(BukkitWrapper.playing.contains(player.getUniqueId())) {
+            if(this.plugin.config.getBoolean("slownessWhilePlaying.disableJumping")) {
+                player.removePotionEffect(PotionEffectType.JUMP);
+            }
+            player.setWalkSpeed(0.2f);
+        }
     }
 
 }

--- a/bukkit/src/main/java/io/github/kosmx/emotes/bukkit/EventListener.java
+++ b/bukkit/src/main/java/io/github/kosmx/emotes/bukkit/EventListener.java
@@ -29,7 +29,7 @@ public class EventListener implements Listener {
             }
         }
         if(plugin.isEnabled() && event.getChannel().equals(BukkitWrapper.Emotepacket)
-                && BukkitWrapper.player_database.get(event.getPlayer().getUniqueId()) == 0){
+                && BukkitWrapper.player_database.getOrDefault(event.getPlayer().getUniqueId(), 0) == 0) {
             BukkitWrapper.player_database.replace(event.getPlayer().getUniqueId(), 2);
         }
     }

--- a/bukkit/src/main/resources/config.yml
+++ b/bukkit/src/main/resources/config.yml
@@ -1,3 +1,11 @@
 debug: true
 validation: false
 validThreshold: 8
+
+# Changes walk speed while playing an emote. Set it to true if you don't want players to run around while playing emotes.
+# 0.2 is normal walking speed, 0.1 is sneaking speed, 0 to completely disable moving while using emotes.
+# It's recommended to also disable jumping, but it's optional and you can enable it if you want to.
+slownessWhilePlaying:
+  enabled: false
+  disableJumping: false
+  speed: 0.1


### PR DESCRIPTION
Added an option to change player speed while playing an emote. Making the speed slower prevents players from unrealistically running while using emotes, and it's a nice feature to have. 

Also fixed this exception: https://paste.gg/p/anonymous/35f0eb907bfd477aadce8ee2370ad694