### PR TITLE
The A in Architectury was lowercase

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs  = -Xmx4G
 
 #Fabric properties
 #See copy-paste
-mod_description = Play emotes in Minecraft\\nOpen the menu to setup your fast-choose wheel\\n\\nYou can add custom emotes, and you can play these even if nobody else has them\\n\\nSpecial thanks:\\nKale Ko for creating emotes and help in the UI design\\nOrsond for inspiring me and providing CollarMC\\narchitectury for the Forge build tools
+mod_description = Play emotes in Minecraft\\nOpen the menu to setup your fast-choose wheel\\n\\nYou can add custom emotes, and you can play these even if nobody else has them\\n\\nSpecial thanks:\\nKale Ko for creating emotes and help in the UI design\\nOrsond for inspiring me and providing CollarMC\\nArchitectury for the Forge build tools
 #Mod properties
 version_base         = 2.1
 maven_group         = io.github.kosmx.emotes


### PR DESCRIPTION
Was working on the wiki and noticed this. Couldn't let it slide lol.