### PR TITLE
Add BungeeCord support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,6 +162,7 @@ else {
 //Build all modules task :D
 task buildAll{
     dependsOn(':bukkit:build')
+    dependsOn(':bungee:build')
     dependsOn(':16:buildAll', ':17:buildAll', ':18:buildAll')
 }
 
@@ -174,6 +175,7 @@ task cleanupArtifacts{
 task collectArtifacts{
     dependsOn('cleanupArtifacts')
     dependsOn(':bukkit:copyArtifacts')
+    dependsOn(':bungee:copyArtifacts')
     dependsOn(':16:copyArtifacts', ':17:copyArtifacts', ':18:copyArtifacts')
     doLast {
         releaseArtifacts = project.getProjectDir().toPath().resolve("artifacts").toFile().listFiles()

--- a/bungee/build.gradle
+++ b/bungee/build.gradle
@@ -1,0 +1,74 @@
+plugins {
+    id 'java'
+    //id "com.github.johnrengelman.shadow" version "6.1.0"
+}
+
+version 'unspecified'
+
+project.archivesBaseName = project.archives_base_name
+//project.version = project.mod_version
+project.version = project.mod_version
+
+repositories {
+    mavenCentral()
+    
+    maven{
+        name = "BungeeMaven"
+        url "https://hub.spigotmc.org/nexus/content/repositories/public/"
+    }
+}
+
+configurations {
+    compileModule
+}
+
+dependencies {
+    //testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
+    //testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+
+    compileOnly "net.md-5:bungeecord-api:${project.bungee_api}"
+
+    implementation project(':emotesAPI')
+    //compileModule(project(':emotesAPI')){ transitive = false }
+
+    implementation project(':executor')
+    //compileModule(project(':executor')){ transitive = false }
+    implementation project(':emotesServer')
+    
+    //compileModule(project(':emotesServer')){ transitive = false }
+    compileModule(project(':emotesMain')){ transitive = false }
+}
+
+processResources{
+
+    inputs.property "version", project.version
+
+    filesMatching("bungee.yml"){
+        expand version: project.version
+    }
+
+}
+
+//shadowJar{
+//    configurations = [project.configurations.compileModule]
+//    classifier "bukkit"
+//}
+
+jar{
+    from{
+        configurations.compileModule.collect() {it.isDirectory() ? it : zipTree(it)}
+    }
+    dependsOn(':emotesMain:build')
+    classifier "bungee"
+}
+
+task copyArtifacts{
+    dependsOn('build')
+    doLast {
+        copy{
+            from "${project.buildDir}/libs/${project.archives_base_name}-${project.mod_version}-bungee.jar"
+            into "${rootProject.projectDir}/artifacts"
+        }
+    }
+}
+

--- a/bungee/src/main/java/io/github/kosmx/emotes/bungee/BungeeWrapper.java
+++ b/bungee/src/main/java/io/github/kosmx/emotes/bungee/BungeeWrapper.java
@@ -1,0 +1,43 @@
+package io.github.kosmx.emotes.bungee;
+
+import io.github.kosmx.emotes.bungee.executor.BungeeInstance;
+import io.github.kosmx.emotes.bungee.network.ServerSideEmotePlay;
+import io.github.kosmx.emotes.common.CommonData;
+import io.github.kosmx.emotes.executor.EmoteInstance;
+import io.github.kosmx.emotes.server.config.Serializer;
+import io.github.kosmx.emotes.server.serializer.UniversalEmoteSerializer;
+import net.md_5.bungee.api.plugin.Plugin;
+
+public class BungeeWrapper extends Plugin {
+    public final static String EmotePacket = CommonData.getIDAsString(CommonData.playEmoteID);
+    public final static String GeyserPacket = "geyser:emote";
+    ServerSideEmotePlay networkPlay = null;
+
+    @Override
+    public void onLoad() {
+        if (CommonData.isLoaded) {
+            getLogger().warning("Emotecraft is loaded multiple times, please load it only once!");
+            this.onDisable(); // disable itself.
+        } else {
+            CommonData.isLoaded = true;
+        }
+        EmoteInstance.instance = new BungeeInstance(this);
+        Serializer.INSTANCE = new Serializer(); // it does register itself
+        EmoteInstance.config = Serializer.getConfig();
+        UniversalEmoteSerializer.loadEmotes();
+    }
+
+    @Override
+    public void onEnable() {
+        this.networkPlay = new ServerSideEmotePlay(this);
+        getProxy().getPluginManager().registerListener(this, networkPlay);
+        super.onEnable();
+        getLogger().info("Loading Emotecraft as a bukkit plugin...");
+    }
+
+    @Override
+    public void onDisable() {
+        super.onDisable();
+        getProxy().unregisterChannel(EmotePacket);
+    }
+}

--- a/bungee/src/main/java/io/github/kosmx/emotes/bungee/executor/BungeeInstance.java
+++ b/bungee/src/main/java/io/github/kosmx/emotes/bungee/executor/BungeeInstance.java
@@ -1,0 +1,50 @@
+package io.github.kosmx.emotes.bungee.executor;
+
+import io.github.kosmx.emotes.bungee.BungeeWrapper;
+import io.github.kosmx.emotes.executor.EmoteInstance;
+import io.github.kosmx.emotes.executor.Logger;
+import io.github.kosmx.emotes.executor.dataTypes.IClientMethods;
+import io.github.kosmx.emotes.executor.dataTypes.IDefaultTypes;
+import io.github.kosmx.emotes.executor.dataTypes.IGetters;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class BungeeInstance extends EmoteInstance {
+    final java.util.logging.Logger logger;
+    final BungeeWrapper plugin;
+
+    public BungeeInstance(BungeeWrapper plugin) {
+        this.logger = plugin.getLogger();
+        this.plugin = plugin;
+    }
+
+    @Override
+    public Logger getLogger() {
+        return this.logger::log;
+    }
+
+    @Override
+    public IDefaultTypes getDefaults() {
+        return null;
+    }
+
+    @Override
+    public IGetters getGetters() {
+        return null;
+    }
+
+    @Override
+    public IClientMethods getClientMethods() {
+        return null;
+    }
+
+    @Override
+    public boolean isClient() {
+        return false;
+    }
+
+    @Override
+    public Path getGameDirectory() {
+        return Paths.get("");
+    }
+}

--- a/bungee/src/main/java/io/github/kosmx/emotes/bungee/network/BungeeNetworkInstance.java
+++ b/bungee/src/main/java/io/github/kosmx/emotes/bungee/network/BungeeNetworkInstance.java
@@ -1,0 +1,38 @@
+package io.github.kosmx.emotes.bungee.network;
+
+import io.github.kosmx.emotes.api.proxy.AbstractNetworkInstance;
+import io.github.kosmx.emotes.common.CommonData;
+import io.github.kosmx.emotes.server.network.IServerNetworkInstance;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.UUID;
+
+public class BungeeNetworkInstance extends AbstractNetworkInstance implements IServerNetworkInstance {
+    private HashMap<Byte, Byte> version = null;
+    final ProxiedPlayer player;
+
+    public BungeeNetworkInstance(ProxiedPlayer player) {
+        this.player = player;
+    }
+
+    @Override
+    public HashMap<Byte, Byte> getVersions() {
+        return version;
+    }
+
+    @Override
+    public void setVersions(HashMap<Byte, Byte> map) {
+        this.version = map;
+    }
+
+    @Override
+    public void sendMessage(byte[] bytes, @Nullable UUID target) {
+        player.sendData(CommonData.getIDAsString(CommonData.playEmoteID), bytes);
+    }
+
+    @Override
+    public boolean isActive() {
+        return true;
+    }
+}

--- a/bungee/src/main/java/io/github/kosmx/emotes/bungee/network/ServerSideEmotePlay.java
+++ b/bungee/src/main/java/io/github/kosmx/emotes/bungee/network/ServerSideEmotePlay.java
@@ -1,0 +1,128 @@
+package io.github.kosmx.emotes.bungee.network;
+
+import io.github.kosmx.emotes.bungee.BungeeWrapper;
+import io.github.kosmx.emotes.common.network.EmotePacket;
+import io.github.kosmx.emotes.common.network.GeyserEmotePacket;
+import io.github.kosmx.emotes.common.network.objects.NetData;
+import io.github.kosmx.emotes.executor.EmoteInstance;
+import io.github.kosmx.emotes.server.network.AbstractServerEmotePlay;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.event.PlayerDisconnectEvent;
+import net.md_5.bungee.api.event.PluginMessageEvent;
+import net.md_5.bungee.api.event.PostLoginEvent;
+import net.md_5.bungee.api.plugin.Listener;
+import net.md_5.bungee.event.EventHandler;
+import java.util.HashMap;
+import java.util.UUID;
+import java.util.logging.Level;
+
+public class ServerSideEmotePlay extends AbstractServerEmotePlay<ProxiedPlayer> implements Listener {
+    final BungeeWrapper plugin;
+
+    final HashMap<UUID, BungeeNetworkInstance> player_database = new HashMap<>();
+
+    public static ServerSideEmotePlay INSTANCE;
+
+    public ServerSideEmotePlay(BungeeWrapper plugin) {
+        this.plugin = plugin;
+        plugin.getProxy().registerChannel(BungeeWrapper.EmotePacket);
+        plugin.getProxy().registerChannel(BungeeWrapper.GeyserPacket);
+    }
+
+    @EventHandler
+    public void receivePluginMessage(PluginMessageEvent event) {
+        EmoteInstance.instance.getLogger().log(Level.FINE, "[EMOTECRAFT] streaming emote");
+        if (event.getTag().equals(BungeeWrapper.EmotePacket)) {
+            if (event.getSender() instanceof ProxiedPlayer) {
+                ProxiedPlayer player = (ProxiedPlayer) event.getSender();
+
+                BungeeNetworkInstance playerNetwork = player_database.getOrDefault(player.getUniqueId(), null);
+                if (playerNetwork != null) {
+                    // Let the common server logic process the message
+                    try {
+                        this.receiveMessage(event.getData(), player, playerNetwork);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                } else {
+                    EmoteInstance.instance.getLogger().log(Level.WARNING, "Player: " + player.getName() + " is not registered");
+                }
+            } else {
+                EmoteInstance.instance.getLogger().log(Level.WARNING, "Uhh oh, sender is not a player");
+            }
+        } else if (event.getTag().equals(BungeeWrapper.GeyserPacket)) {
+            if (event.getSender() instanceof ProxiedPlayer) {
+                ProxiedPlayer player = (ProxiedPlayer) event.getSender();
+
+                receiveGeyserMessage(player, event.getData());
+            } else {
+                EmoteInstance.instance.getLogger().log(Level.WARNING, "Uhh oh, sender is not a player");
+            }
+        }
+    }
+
+    @Override
+    protected UUID getUUIDFromPlayer(ProxiedPlayer player) {
+        return player.getUniqueId();
+    }
+
+    @Override
+    protected long getRuntimePlayerID(ProxiedPlayer player) {
+        return player.getUniqueId().getMostSignificantBits() & Long.MAX_VALUE;
+    }
+
+    @Override
+    protected void sendForEveryoneElse(GeyserEmotePacket packet, ProxiedPlayer player) {
+        for (ProxiedPlayer player1 : plugin.getProxy().getPlayers()) {
+            if (player1 != player) {
+                try {
+                    player1.sendData(BungeeWrapper.GeyserPacket, packet.write());
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void sendForEveryoneElse(NetData data, GeyserEmotePacket emotePacket, ProxiedPlayer player) {
+        for (ProxiedPlayer player1 : plugin.getProxy().getPlayers()) {
+            if (player1 != player) {
+                try {
+                    player1.sendData(BungeeWrapper.EmotePacket, new EmotePacket.Builder(data).build().write().array());
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void sendForPlayerInRange(NetData data, ProxiedPlayer player, UUID target) {
+        sendForPlayer(data, player, target);
+    }
+
+    @Override
+    protected void sendForPlayer(NetData data, ProxiedPlayer player, UUID target) {
+        ProxiedPlayer targetPlayer = plugin.getProxy().getPlayer(target);
+        try {
+            targetPlayer.sendData(BungeeWrapper.EmotePacket, new EmotePacket.Builder(data).build().write().array());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PostLoginEvent event) {
+        this.player_database.put(event.getPlayer().getUniqueId(), new BungeeNetworkInstance(event.getPlayer()));
+    }
+
+    @EventHandler
+    public void onPlayerLeave(PlayerDisconnectEvent event) {
+        ProxiedPlayer player = event.getPlayer();
+
+        BungeeNetworkInstance instance = this.player_database.remove(player.getUniqueId());
+        if (instance != null)
+            instance.closeConnection();
+    }
+}

--- a/bungee/src/main/resources/bungee.yml
+++ b/bungee/src/main/resources/bungee.yml
@@ -1,0 +1,3 @@
+name: emotecraft
+main: io.github.kosmx.emotes.bungee.BungeeWrapper
+version: ${version}

--- a/bungee/src/main/resources/config.yml
+++ b/bungee/src/main/resources/config.yml
@@ -1,3 +1,0 @@
-debug: true
-validation: false
-validThreshold: 8

--- a/bungee/src/main/resources/config.yml
+++ b/bungee/src/main/resources/config.yml
@@ -1,0 +1,3 @@
+debug: true
+validation: false
+validThreshold: 8

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,7 @@ java_version        = 8
 #bendylib_version   = 2.0-SNAPSHOT11
 
 spigot_api      = 1.15.2-R0.1-SNAPSHOT
+bungee_api      = 1.16-R0.5-SNAPSHOT
 
 #Copy-pasta part from https://modmuss50.me/fabric.html
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -50,3 +50,6 @@ include '18:forge'
 //Bukkit plugin stuff
 include 'bukkit'
 include 'bukkit:debug'
+
+//Bungee plugin stuff
+include 'bungee'


### PR DESCRIPTION
Added support for running the emotecraft plugin on BungeeCord so you only need to install it in one place with one config.

Tested on a Waterfall 1.18 server with a fabric 1.18.1 client running emotecraft-2.1-SNAPSHOT-build.10