### PR TITLE
Revert "Bump com.github.breadmoirai.github-release from 2.3.7 to 2.3.12"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins{
     //id "com.dorongold.task-tree" version "1.5" Current version doesn't support gradle 6.8
 
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id "com.github.breadmoirai.github-release" version "2.3.12"
+    id "com.github.breadmoirai.github-release" version "2.3.7"
     id "com.modrinth.minotaur" version "2.1.2" apply false
     id "io.freefair.lombok" version "6.4.3" apply false
 }


### PR DESCRIPTION
Reverts KosmX/emotes#231 because the plugin does **not** have new version.