### PR TITLE
Fabric Server fix error : Caused by: java.lang.NullPointerException: …

### DIFF
--- a/minecraft/archCommon/src/main/java/io/github/kosmx/emotes/arch/network/CommonServerNetworkHandler.java
+++ b/minecraft/archCommon/src/main/java/io/github/kosmx/emotes/arch/network/CommonServerNetworkHandler.java
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
 public final class CommonServerNetworkHandler extends AbstractServerEmotePlay<ServerPlayer> {
     public static CommonServerNetworkHandler instance = new CommonServerNetworkHandler();
 
-    private static MinecraftServer server = null;
+    private static MinecraftServer server;
 
     public static void setServer(@NotNull MinecraftServer server) {
         CommonServerNetworkHandler.server = server;
@@ -49,7 +49,6 @@ public final class CommonServerNetworkHandler extends AbstractServerEmotePlay<Se
     }
 
     public void init() {
-
     }
 
     private byte[] unwrapBuffer(FriendlyByteBuf buf) {

--- a/minecraft/fabric/src/main/java/io/github/kosmx/emotes/fabric/FabricWrapper.java
+++ b/minecraft/fabric/src/main/java/io/github/kosmx/emotes/fabric/FabricWrapper.java
@@ -1,6 +1,7 @@
 package io.github.kosmx.emotes.fabric;
 
 import io.github.kosmx.emotes.arch.ServerCommands;
+import io.github.kosmx.emotes.arch.network.CommonServerNetworkHandler;
 import io.github.kosmx.emotes.common.CommonData;
 import io.github.kosmx.emotes.executor.EmoteInstance;
 import io.github.kosmx.emotes.fabric.executor.FabricEmotesMain;
@@ -9,6 +10,7 @@ import io.github.kosmx.emotes.main.MainLoader;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerWorldEvents;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.server.MinecraftServer;
@@ -63,5 +65,6 @@ public class FabricWrapper implements ModInitializer {
         });
 
         CommandRegistrationCallback.EVENT.register(ServerCommands::register);
+        ServerLifecycleEvents.SERVER_STARTED.register(CommonServerNetworkHandler::setServer);
     }
 }


### PR DESCRIPTION
…Cannot invoke "net.minecraft.server.MinecraftServer.getPlayerList()" because "io.github.kosmx.emotes.arch.network.CommonServerNetworkHandler.server" is null

Fixed a bug for the Fabric server when the player crashes when stopping emotions via shift