### PR TITLE
Allow config to store everything

### DIFF
--- a/emotesAPI/src/main/java/io/github/kosmx/emotes/common/SerializableConfig.java
+++ b/emotesAPI/src/main/java/io/github/kosmx/emotes/common/SerializableConfig.java
@@ -20,29 +20,29 @@ public class SerializableConfig {
 
     public int configVersion; //this has a different job... not a config
 
-    public final BooleanConfigEntry showDebug = new BooleanConfigEntry("debug", "showDebug", true, false, expert);
-    public final BooleanConfigEntry validateEmote = new BooleanConfigEntry("validate", false, true, expert);
+    public final ConfigEntry<Boolean> showDebug = new ConfigEntry<>("debug", "showDebug", true, false, expert);
+    public final ConfigEntry<Boolean> validateEmote = new ConfigEntry<>("validate", false, true, expert);
 
-    public final FloatConfigEntry validThreshold = new FloatConfigEntry("validationThreshold", "validThreshold", 8f, true, expert, "options.generic_value", 0.2f, 16f, 0f);
+    public final ConfigEntry<Float> validThreshold = new FloatConfigEntry("validationThreshold", "validThreshold", 8f, true, expert, "options.generic_value", 0.2f, 16f, 0f);
 
-    public final ConfigEntry<Boolean> loadBuiltinEmotes = new BooleanConfigEntry("loadbuiltin", "loadBuiltin", true, true, basics);
-    public final BooleanConfigEntry loadEmotesServerSide = new BooleanConfigEntry("emotesFolderOnLogicalServer", false, true, expert, true);
-    public final ConfigEntry<Boolean> enableQuark = new BooleanConfigEntry("quark", "enablequark", false, true, basics);
+    public final ConfigEntry<Boolean> loadBuiltinEmotes = new ConfigEntry<>("loadbuiltin", "loadBuiltin", true, true, basics);
+    public final ConfigEntry<Boolean> loadEmotesServerSide = new ConfigEntry<>("emotesFolderOnLogicalServer", false, true, expert, true);
+    public final ConfigEntry<Boolean> enableQuark = new ConfigEntry<>("quark", "enablequark", false, true, basics);
 
-    public final StringConfigEntry emotesDir = new StringConfigEntry("emotesDirectory", "emotes", false, expert, true);
+    public final ConfigEntry<String> emotesDir = new ConfigEntry<>("emotesDirectory", "emotes", false, expert, true);
 
-    public final BooleanConfigEntry autoFixEmoteStop = new BooleanConfigEntry("autoFixEmoteStop", true, true, expert, false);
+    public final ConfigEntry<Boolean> autoFixEmoteStop = new ConfigEntry<>("autoFixEmoteStop", true, true, expert, false);
 
-    public void iterate(Consumer<ConfigEntry<?>> consumer){
+    public void iterate(Consumer<ConfigEntry<?>> consumer) {
         basics.forEach(consumer);
         expert.forEach(consumer);
     }
 
-    public void iterateGeneral(Consumer<ConfigEntry<?>> consumer){
+    public void iterateGeneral(Consumer<ConfigEntry<?>> consumer) {
         basics.forEach(consumer);
     }
 
-    public void iterateExpert(Consumer<ConfigEntry<?>> consumer){
+    public void iterateExpert(Consumer<ConfigEntry<?>> consumer) {
         expert.forEach(consumer);
     }
 
@@ -50,14 +50,14 @@ public class SerializableConfig {
         loadEmotesServerSide.set(true);
     }
 
-    public static abstract class ConfigEntry<T>{
+    public static class ConfigEntry<T> {
         final String name, oldConfig; //oldconfig for the old config name
         T value;
         final T defaultValue;
         final public boolean hasTooltip;
         final boolean isHidden;
 
-        public ConfigEntry(String name, String oldconfig, T defVal, boolean hasTooltip, List<ConfigEntry<?>> collection, boolean hidden){
+        public ConfigEntry(String name, String oldconfig, T defVal, boolean hasTooltip, List<ConfigEntry<?>> collection, boolean hidden) {
             this.name = name;
             this.oldConfig = oldconfig;
             this.hasTooltip = hasTooltip;
@@ -67,59 +67,44 @@ public class SerializableConfig {
             isHidden = hidden;
         }
 
-        public ConfigEntry(String name, String oldconfig, T defVal, boolean hasTooltip, List<ConfigEntry<?>> collection){
+        public ConfigEntry(String name, String oldconfig, T defVal, boolean hasTooltip, List<ConfigEntry<?>> collection) {
             this(name, oldconfig, defVal, hasTooltip, collection, false);
         }
-        public ConfigEntry(String name, T defVal, boolean hasTooltip, List<ConfigEntry<?>> collection){
+
+        public ConfigEntry(String name, T defVal, boolean hasTooltip, List<ConfigEntry<?>> collection) {
             this(name, null, defVal, hasTooltip, collection);
         }
-        public ConfigEntry(String name, T defVal, List<ConfigEntry<?>> collection, boolean hidden){
+
+        public ConfigEntry(String name, T defVal, List<ConfigEntry<?>> collection, boolean hidden) {
             this(name, null, defVal, false, collection, hidden);
         }
 
-        public T get(){
+        public ConfigEntry(String name, T defVal, boolean hasTooltip, List<ConfigEntry<?>> collection, boolean hidden) {
+            this(name, null, defVal, hasTooltip, collection, hidden);
+        }
+
+        public T get() {
             return value;
         }
 
-        public void set(T newValue){
+        public void set(T newValue) {
             this.value = newValue;
         }
 
-        public String getName(){
+        public String getName() {
             return name;
         }
-        public String getOldConfigName(){
+
+        public String getOldConfigName() {
             return oldConfig;
         }
 
-        public void resetToDefault(){
+        public void resetToDefault() {
             this.value = this.defaultValue;
         }
 
-        public boolean showEntry(){
+        public boolean showEntry() {
             return !isHidden;
-        }
-
-    }
-
-    public static class BooleanConfigEntry extends ConfigEntry<Boolean>{
-
-        public BooleanConfigEntry(String name, String oldconfig, Boolean defVal, boolean hasTooltip, List<ConfigEntry<?>> collection, boolean hidden) {
-            super(name, oldconfig, defVal, hasTooltip, collection, hidden);
-        }
-        public BooleanConfigEntry(String name, String oldconfig, Boolean defVal, boolean hasTooltip, List<ConfigEntry<?>> collection) {
-            super(name, oldconfig, defVal, hasTooltip, collection);
-        }
-
-        public BooleanConfigEntry(String name, Boolean defVal, boolean hasTooltip, List<ConfigEntry<?>> collection, boolean hidden) {
-            super(name, null, defVal, hasTooltip, collection, hidden);
-        }
-
-        public BooleanConfigEntry(String name, Boolean defVal, boolean hasTooltip, List<ConfigEntry<?>> collection) {
-            super(name, defVal, hasTooltip, collection);
-        }
-        public BooleanConfigEntry(String name, Boolean defVal, List<ConfigEntry<?>> collection, boolean hidden) {
-            super(name, defVal, collection, hidden);
         }
     }
 
@@ -151,20 +136,6 @@ public class SerializableConfig {
         }
         public double getTextVal(){
             return get();
-        }
-    }
-
-    public static class StringConfigEntry extends ConfigEntry<String> {
-        public StringConfigEntry(String name, String defVal, boolean hasTooltip, List<ConfigEntry<?>> collection, boolean hidden) {
-            super(name, null, defVal, hasTooltip, collection, hidden);
-        }
-
-        public StringConfigEntry(String name, String defVal, boolean hasTooltip, List<ConfigEntry<?>> collection) {
-            super(name, defVal, hasTooltip, collection);
-        }
-
-        public StringConfigEntry(String name, String defVal, List<ConfigEntry<?>> collection, boolean hidden) {
-            super(name, defVal, collection, hidden);
         }
     }
 }

--- a/emotesAPI/src/main/java/io/github/kosmx/emotes/common/SerializableConfig.java
+++ b/emotesAPI/src/main/java/io/github/kosmx/emotes/common/SerializableConfig.java
@@ -145,8 +145,12 @@ public class SerializableConfig {
 
     @SuppressWarnings("unused")
     public static class ListConfigEntry<T> extends ConfigEntry<List<T>> {
-        public ListConfigEntry(String name, List<T> defVal, boolean hasTooltip, List<ConfigEntry<?>> collection, boolean hidden) {
-            super(name, null, defVal, hasTooltip, collection, hidden);
+        public ListConfigEntry(String name, String oldconfig, List<T> defVal, boolean hasTooltip, List<ConfigEntry<?>> collection, boolean hidden) {
+            super(name, oldconfig, defVal, hasTooltip, collection, hidden);
+        }
+
+        public ListConfigEntry(String name, String oldconfig, List<T> defVal, boolean hasTooltip, List<ConfigEntry<?>> collection) {
+            super(name, oldconfig, defVal, hasTooltip, collection);
         }
 
         public ListConfigEntry(String name, List<T> defVal, boolean hasTooltip, List<ConfigEntry<?>> collection) {
@@ -155,6 +159,10 @@ public class SerializableConfig {
 
         public ListConfigEntry(String name, List<T> defVal, List<ConfigEntry<?>> collection, boolean hidden) {
             super(name, defVal, collection, hidden);
+        }
+
+        public ListConfigEntry(String name, List<T> defVal, boolean hasTooltip, List<ConfigEntry<?>> collection, boolean hidden) {
+            super(name, defVal, hasTooltip, collection, hidden);
         }
     }
 }

--- a/emotesAPI/src/main/java/io/github/kosmx/emotes/common/SerializableConfig.java
+++ b/emotesAPI/src/main/java/io/github/kosmx/emotes/common/SerializableConfig.java
@@ -108,11 +108,14 @@ public class SerializableConfig {
         }
     }
 
+    @SuppressWarnings("unused")
     public static class FloatConfigEntry extends ConfigEntry<Float> {
-        final private String formatKey;
+        private final String formatKey;
         public final float min, max, step;
+
         public FloatConfigEntry(String name, String oldconfig, Float defVal, boolean hasTooltip, List<ConfigEntry<?>> collection, String formatKey, float min, float max, float step) {
             super(name, oldconfig, defVal, hasTooltip, collection);
+
             this.formatKey = formatKey;
             this.min = min;
             this.max = max;
@@ -121,21 +124,37 @@ public class SerializableConfig {
 
         public FloatConfigEntry(String name, Float defVal, boolean hasTooltip, List<ConfigEntry<?>> collection, String formatKey, float min, float step, float max) {
             this(name, null, defVal, hasTooltip, collection, formatKey, min, max, step);
-
         }
 
         public String getFormatKey() {
             return formatKey;
         }
 
-        public double getConfigVal(){
+        public double getConfigVal() {
             return Math.sqrt(this.get());
         }
-        public void setConfigVal(double newVal){
+
+        public void setConfigVal(double newVal) {
             this.set((float) Math.pow(newVal, 2));
         }
-        public double getTextVal(){
+
+        public double getTextVal() {
             return get();
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class ListConfigEntry<T> extends ConfigEntry<List<T>> {
+        public ListConfigEntry(String name, List<T> defVal, boolean hasTooltip, List<ConfigEntry<?>> collection, boolean hidden) {
+            super(name, null, defVal, hasTooltip, collection, hidden);
+        }
+
+        public ListConfigEntry(String name, List<T> defVal, boolean hasTooltip, List<ConfigEntry<?>> collection) {
+            super(name, defVal, hasTooltip, collection);
+        }
+
+        public ListConfigEntry(String name, List<T> defVal, List<ConfigEntry<?>> collection, boolean hidden) {
+            super(name, defVal, collection, hidden);
         }
     }
 }

--- a/minecraft/archCommon/src/main/java/io/github/kosmx/emotes/arch/gui/screen/ConfigScreen.java
+++ b/minecraft/archCommon/src/main/java/io/github/kosmx/emotes/arch/gui/screen/ConfigScreen.java
@@ -78,20 +78,14 @@ public class ConfigScreen extends OptionsSubScreen {
         this.addWidget(options);
     }
 
-    private void addConfigEntry(SerializableConfig.ConfigEntry<?> entry, OptionsList options) {
+    private <T> void addConfigEntry(SerializableConfig.ConfigEntry<T> entry, OptionsList options) {
         if (entry.showEntry() || ((ClientConfig) EmoteInstance.config).showHiddenConfig.get()) {
-            if (entry instanceof SerializableConfig.BooleanConfigEntry) {
-                if (entry.hasTooltip) {
-                    options.addBig(OptionInstance.createBoolean("emotecraft.otherconfig." + entry.getName(),
-                            aBoolean -> Tooltip.create(Component.translatable("emotecraft.otherconfig." + entry.getName() + ".tooltip")), ((SerializableConfig.BooleanConfigEntry) entry).get(),
-                            (aBoolean) -> ((SerializableConfig.BooleanConfigEntry) entry).set(aBoolean)
-                    ));
-                } else {
-                    options.addBig(OptionInstance.createBoolean("emotecraft.otherconfig." + entry.getName(),
-                            OptionInstance.noTooltip(), ((SerializableConfig.BooleanConfigEntry) entry).get(),
-                            (aBoolean) -> ((SerializableConfig.BooleanConfigEntry) entry).set(aBoolean)
-                    ));
-                }
+            if (entry.get() instanceof Boolean b) {
+                options.addBig(OptionInstance.createBoolean("emotecraft.otherconfig." + entry.getName(),
+                        entry.hasTooltip ? aBoolean -> Tooltip.create(Component.translatable("emotecraft.otherconfig." + entry.getName() + ".tooltip")) : OptionInstance.noTooltip(),
+                        b, (aBoolean) -> entry.set((T) aBoolean)
+                ));
+
             } else if (entry instanceof SerializableConfig.FloatConfigEntry floatEntry) {
                 /*options.addBig(new ProgressOption(
                         EmoteInstance.config.validThreshold.getName(), floatEntry.min, floatEntry.max, floatEntry.step,

--- a/minecraft/archCommon/src/main/java/io/github/kosmx/emotes/main/config/ClientConfig.java
+++ b/minecraft/archCommon/src/main/java/io/github/kosmx/emotes/main/config/ClientConfig.java
@@ -8,18 +8,18 @@ import java.util.UUID;
 
 public class ClientConfig extends SerializableConfig {
 
-    public final BooleanConfigEntry dark = new BooleanConfigEntry("dark", false, false, basics);
+    public final ConfigEntry<Boolean> dark = new ConfigEntry<>("dark", false, false, basics);
 
-    public final BooleanConfigEntry oldChooseWheel = new BooleanConfigEntry("oldChooseWheel", false, false, basics);
-    public final ConfigEntry<Boolean> enablePerspective = new BooleanConfigEntry("perspective", true, false, basics);
-    public final BooleanConfigEntry frontAsTPPerspective = new BooleanConfigEntry("default3rdPersonFront", false, false, basics);
-    public final ConfigEntry<Boolean> showIcons = new BooleanConfigEntry("showicon", "showIcon", true, false, basics);
-    public final ConfigEntry<Boolean> enableNSFW = new BooleanConfigEntry("enableNSFW", false, true, basics);
+    public final ConfigEntry<Boolean> oldChooseWheel = new ConfigEntry<>("oldChooseWheel", false, false, basics);
+    public final ConfigEntry<Boolean> enablePerspective = new ConfigEntry<>("perspective", true, false, basics);
+    public final ConfigEntry<Boolean> frontAsTPPerspective = new ConfigEntry<>("default3rdPersonFront", false, false, basics);
+    public final ConfigEntry<Boolean> showIcons = new ConfigEntry<>("showicon", "showIcon", true, false, basics);
+    public final ConfigEntry<Boolean> enableNSFW = new ConfigEntry<>("enableNSFW", false, true, basics);
 
-    public final ConfigEntry<Boolean> alwaysOpenEmoteScreen = new BooleanConfigEntry("alwaysOpenScreen", false, true, basics);
+    public final ConfigEntry<Boolean> alwaysOpenEmoteScreen = new ConfigEntry<>("alwaysOpenScreen", false, true, basics);
     //expert
-    public final ConfigEntry<Boolean> alwaysValidate = new BooleanConfigEntry("alwaysValidateEmote", false, true, expert);
-    public final ConfigEntry<Boolean> enablePlayerSafety = new BooleanConfigEntry("playersafety", true, true, expert);
+    public final ConfigEntry<Boolean> alwaysValidate = new ConfigEntry<>("alwaysValidateEmote", false, true, expert);
+    public final ConfigEntry<Boolean> enablePlayerSafety = new ConfigEntry<>("playersafety", true, true, expert);
     public final ConfigEntry<Float> stopThreshold = new FloatConfigEntry("stopthreshold", "stopThreshold", 0.04f, true, expert, "options.generic_value", -3.912f, 8f, 0f){
         @Override
         public double getConfigVal() {
@@ -48,9 +48,9 @@ public class ClientConfig extends SerializableConfig {
             return this.getConfigVal();
         }
     };
-    public final ConfigEntry<Boolean> showHiddenConfig = new BooleanConfigEntry("showHiddenConfig", false, true, expert, false);
-    public final ConfigEntry<Boolean> neverRemoveBadIcon = new BooleanConfigEntry("neverRemoveBadIcon", false, expert, true);
-    public final ConfigEntry<Boolean> exportBuiltin = new BooleanConfigEntry("exportBuiltin", false, expert, true);
+    public final ConfigEntry<Boolean> showHiddenConfig = new ConfigEntry<>("showHiddenConfig", false, true, expert, false);
+    public final ConfigEntry<Boolean> neverRemoveBadIcon = new ConfigEntry<>("neverRemoveBadIcon", false, expert, true);
+    public final ConfigEntry<Boolean> exportBuiltin = new ConfigEntry<>("exportBuiltin", false, expert, true);
 
 
 
@@ -70,5 +70,5 @@ public class ClientConfig extends SerializableConfig {
 
     //------------------------ Random tweak stuff ------------------------//
 
-    public final ConfigEntry<Boolean> hideWarningMessage = new BooleanConfigEntry("hideWarning", false, expert, true);
+    public final ConfigEntry<Boolean> hideWarningMessage = new ConfigEntry<>("hideWarning", false, expert, true);
 }


### PR DESCRIPTION
Allow config to store any values

Personally, I use the emotecraft config api wherever it is available (for example, in my discord bot).

<details>
This doesn't break old configs, but it might be worth checking deserialization, as I'm not sure about entry.get().getClass() (maybe store TypeToken?)
</details>