### PR TITLE
fix: do not Override tick in EmotePlayerMixin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.parallel=true
 
 # Mod Properties
     mod_description = Play emotes in Minecraft\\nOpen the menu to setup your fast-choose wheel\\n\\nYou can add custom emotes, and you can play these even if nobody else has them\\n\\nSpecial thanks:\\nKale Ko for creating emotes and help in the UI design\\nOrsond for inspiring me and providing CollarMC\\nArchitectury for the Forge build tools
-    version_base = 2.4.7
+    version_base = 2.4.8
     maven_group = io.github.kosmx.emotes
     archives_base_name = emotecraft
 

--- a/minecraft/archCommon/src/main/java/io/github/kosmx/emotes/arch/mixin/EmotePlayerMixin.java
+++ b/minecraft/archCommon/src/main/java/io/github/kosmx/emotes/arch/mixin/EmotePlayerMixin.java
@@ -53,6 +53,11 @@ public abstract class EmotePlayerMixin extends Player implements IPlayerEntity {
         ((IPlayer)this).getAnimationStack().addAnimLayer(1000, emotecraftEmoteContainer);
     }
 
+    @Inject(method = "tick", at = @At("TAIL"))
+    private void injectEmoteTick(CallbackInfo ci) {
+        this.emoteTick();
+    }
+
     @Override
     public void emotecraft$playEmote(KeyframeAnimation emote, int t, boolean isForced) {
         this.emotecraftEmoteContainer.setAnim(new EmotePlayImpl(emote, this::emotecraft$noteConsumer, t));
@@ -134,12 +139,6 @@ public abstract class EmotePlayerMixin extends Player implements IPlayerEntity {
     @Override
     public void emotecraft$setBodyYaw(float newYaw) {
         this.yBodyRot = newYaw;
-    }
-
-    @Override
-    public void tick() {
-        super.tick();
-        this.emoteTick();
     }
 
     @Override

--- a/minecraft/archCommon/src/main/java/io/github/kosmx/emotes/arch/mixin/EmotePlayerMixin.java
+++ b/minecraft/archCommon/src/main/java/io/github/kosmx/emotes/arch/mixin/EmotePlayerMixin.java
@@ -53,11 +53,6 @@ public abstract class EmotePlayerMixin extends Player implements IPlayerEntity {
         ((IPlayer)this).getAnimationStack().addAnimLayer(1000, emotecraftEmoteContainer);
     }
 
-    @Inject(method = "tick", at = @At("TAIL"))
-    private void injectEmoteTick(CallbackInfo ci) {
-        this.emoteTick();
-    }
-
     @Override
     public void emotecraft$playEmote(KeyframeAnimation emote, int t, boolean isForced) {
         this.emotecraftEmoteContainer.setAnim(new EmotePlayImpl(emote, this::emotecraft$noteConsumer, t));
@@ -139,6 +134,11 @@ public abstract class EmotePlayerMixin extends Player implements IPlayerEntity {
     @Override
     public void emotecraft$setBodyYaw(float newYaw) {
         this.yBodyRot = newYaw;
+    }
+
+    @Inject(method = "tick", at = @At(value = "TAIL"))
+    public void tick(CallbackInfo ci) {
+        this.emoteTick();
     }
 
     @Override


### PR DESCRIPTION
In `EmotePlayerMixin`, `@Override` is used on the vanilla tick method. This is very bad for compatibility for reasons I will now explain.

When you `@Override` a method from the target's parent, Mixin will **silently overwrite the method with your implementation**. If multiple mixins try this, **whichever mixin happens to be applied last "wins"**. Calling `super.tick()` doesn't help here - it will call the `tick` method *of the parent class* (`Player` in our case)
So, when `EmotePlayerMixin` overrides `tick`, Mixin replaces the `tick` inside `AbstractClientPlayer` with `tick` inside `EmotePlayerMixin`:

Before:
```java
    public void tick() {
        this.deltaMovementOnPreviousTick = this.getDeltaMovement();
        super.tick(); // Player.this.tick();
    }
```
After:
```java
    public void tick() {
        super.tick(); // Player.this.tick();
        this.emoteTick();
    }
```

The vanilla behavior of updating the `deltaMovementOnPreviousTick` field is now lost. If any other mixins into this method are applied before Emotecraft's, their changes are lost too.

See Octol1ttle/FlightAssistant#39. I use `AbstractClientPlayer#getDeltaMovementLerped` to get the player's velocity. The method relies on `deltaMovementOnPreviousTick` being updated correctly. Because `EmotePlayerMixin` overwrites this behavior, my mod breaks in various ways.

Vanilla uses this method for player model rendering, although I cannot describe in detail how it is being affected by this bug

This PR fixes this issue by removing the `@Override` using `@Inject` at `TAIL`.