### PR TITLE
CurseForge and Modrinth versioning fixes for non-releases

### DIFF
--- a/buildSrc/src/main/java/ProjectExtensions.kt
+++ b/buildSrc/src/main/java/ProjectExtensions.kt
@@ -27,7 +27,7 @@ val Project.minecraft_version
     get() = properties["minecraft_version"] as String
 
 val Project.curseforge_minecraft_version: String
-    get() = properties["curseforge_minecraft_version"] as? String ?: minecraft_version
+    get() = asCurseForgeVersion(minecraft_version, properties["minecraft_release_version"] as? String)
 
 val Project.parchment_version
     get() = properties["parchment_version"] as String

--- a/buildSrc/src/main/java/Utils.kt
+++ b/buildSrc/src/main/java/Utils.kt
@@ -22,6 +22,13 @@ fun asCurseForgeVersion(full: String, release: String?): String {
     } else return full // release version
 }
 
+/**
+ * Removes -pre and -rc suffixes to kepp only release version
+ */
+fun removePreRc(mcVer: String): String {
+    return mcVer.split("-").first()
+}
+
 private fun runCommand(cmd: String): Pair<Int, String> {
     val p = Runtime.getRuntime().exec(cmd.split(" ").toTypedArray())
     return p.waitFor() to p.inputReader().readText().trim()

--- a/buildSrc/src/main/java/Utils.kt
+++ b/buildSrc/src/main/java/Utils.kt
@@ -23,7 +23,7 @@ fun asCurseForgeVersion(full: String, release: String?): String {
 }
 
 /**
- * Removes -pre and -rc suffixes to kepp only release version
+ * Removes -pre and -rc suffixes to keep only release version
  */
 fun removePreRc(mcVer: String): String {
     return mcVer.split("-").first()

--- a/buildSrc/src/main/java/Utils.kt
+++ b/buildSrc/src/main/java/Utils.kt
@@ -17,7 +17,7 @@ fun asCurseForgeVersion(full: String, release: String?): String {
         if (release == null) throw IllegalArgumentException("Version is snapshot but no release provided")
         return release+"-Snapshot" // release is unknown for snapshot number, so use argument
     } else if ("-" in full) { // rc and pre
-        val majorMinorPatch = full.split("-", limit = 1).first() // extract release
+        val majorMinorPatch = full.split("-").first() // extract release
         return majorMinorPatch+"-Snapshot"
     } else return full // release version
 }

--- a/buildSrc/src/main/java/Utils.kt
+++ b/buildSrc/src/main/java/Utils.kt
@@ -12,6 +12,16 @@ import org.gradle.kotlin.dsl.maven
 import org.w3c.dom.Element
 
 
+fun asCurseForgeVersion(full: String, release: String?): String {
+    if ("w" in full) { // snapshots
+        if (release == null) throw IllegalArgumentException("Version is snapshot but no release provided")
+        return release+"-Snapshot" // release is unknown for snapshot number, so use argument
+    } else if ("-" in full) { // rc and pre
+        val majorMinorPatch = full.split("-", limit = 1).first() // extract release
+        return majorMinorPatch+"-Snapshot"
+    } else return full // release version
+}
+
 private fun runCommand(cmd: String): Pair<Int, String> {
     val p = Runtime.getRuntime().exec(cmd.split(" ").toTypedArray())
     return p.waitFor() to p.inputReader().readText().trim()

--- a/buildSrc/src/main/java/Utils.kt
+++ b/buildSrc/src/main/java/Utils.kt
@@ -15,7 +15,7 @@ import org.w3c.dom.Element
 fun asCurseForgeVersion(full: String, release: String?): String {
     if ("w" in full) { // snapshots
         if (release == null) throw IllegalArgumentException("Version is snapshot but no release provided")
-        return release+"-Snapshot" // release is unknown for snapshot number, so use argument
+        return release+"-Snapshot" // release is unknown for snapshot, so use argument
     } else if ("-" in full) { // rc and pre
         val majorMinorPatch = full.split("-").first() // extract release
         return majorMinorPatch+"-Snapshot"

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,11 +8,11 @@ loom.ignoreDependencyLoomVersionValidation=true
     curseforge_slug_forge = emotecraft-forge
     curseforge_id_fabric = 397809
     curseforge_slug_fabric = emotecraft
-    curseforge_minecraft_version = 1.21.5-Snapshot
     hangar_id = emotecraft
 
 # Properties
     minecraft_version = 1.21.5-pre2
+    minecraft_release_version = 1.21.5
     parchment_version = 2025.03.16
     fabric_loader_version = 0.16.10
     neoforge_version = 21.4.109-beta

--- a/minecraft/fabric/build.gradle.kts
+++ b/minecraft/fabric/build.gradle.kts
@@ -156,7 +156,7 @@ publishMods {
         projectId = providers.gradleProperty("modrinth_id")
         minecraftVersions.add(minecraft_version)
         displayName = mod_version
-        version = "${mod_version}+${minecraft_version}-fabric"
+        version = "${mod_version}+${removePreRc(minecraft_version)}-fabric"
 
         requires("fabric-api")
         embeds("playeranimator")

--- a/minecraft/neoforge/build.gradle.kts
+++ b/minecraft/neoforge/build.gradle.kts
@@ -139,7 +139,7 @@ publishMods {
         projectId = providers.gradleProperty("modrinth_id")
         minecraftVersions.add(minecraft_version)
         displayName = mod_version
-        version = "${mod_version}+${minecraft_version}-forge"
+        version = "${mod_version}+${removePreRc(minecraft_version)}-forge"
 
         embeds("playeranimator")
         optional("searchables")

--- a/paper/build.gradle.kts
+++ b/paper/build.gradle.kts
@@ -101,7 +101,7 @@ publishMods {
         projectId = providers.gradleProperty("modrinth_id")
         minecraftVersions.add(minecraft_version)
         displayName = mod_version
-        version = "${mod_version}+${minecraft_version}-paper"
+        version = "${mod_version}+${removePreRc(minecraft_version)}-paper"
     }
 }
 


### PR DESCRIPTION
* Strip `-rcN` and `-preN` suffixes from modrinth version number to keep it in 32 symbols limit.
* Convert minecraft version for CurseForge.
* When converting minecraft snapshot version for CurseForge, new property `minecraft_release_version` is used.