### PR TITLE
Proper disabling on a Paper server

### DIFF
--- a/paper/src/main/java/io/github/kosmx/emotes/bukkit/BukkitWrapper.java
+++ b/paper/src/main/java/io/github/kosmx/emotes/bukkit/BukkitWrapper.java
@@ -65,6 +65,8 @@ public class BukkitWrapper extends JavaPlugin implements ChannelInitializeListen
         Bukkit.getMessenger().unregisterOutgoingPluginChannel(this, EMOTE_PACKET);
         Bukkit.getMessenger().unregisterIncomingPluginChannel(this, EMOTE_PACKET);
         HandlerList.unregisterAll(ServerSideEmotePlay.getInstance());
+
+        CommonData.LOGGER.warn("Emotecraft does not support disabling by PlugMan and similar plugins");
     }
 
     @Override

--- a/paper/src/main/java/io/github/kosmx/emotes/bukkit/BukkitWrapper.java
+++ b/paper/src/main/java/io/github/kosmx/emotes/bukkit/BukkitWrapper.java
@@ -60,9 +60,7 @@ public class BukkitWrapper extends JavaPlugin implements ChannelInitializeListen
     }
 
     @Override
-    public void onDisable() {
-        throw new UnsupportedOperationException("Emotecraft does not support disabling, ignore this error when shutting down the server...");
-    }
+    public void onDisable() {}
 
     @Override
     public void afterInitChannel(@NotNull Channel channel) {

--- a/paper/src/main/java/io/github/kosmx/emotes/bukkit/BukkitWrapper.java
+++ b/paper/src/main/java/io/github/kosmx/emotes/bukkit/BukkitWrapper.java
@@ -17,6 +17,7 @@ import net.kyori.adventure.key.Key;
 import net.minecraft.network.protocol.common.ServerboundCustomPayloadPacket;
 import net.minecraft.network.protocol.common.custom.DiscardedPayload;
 import org.bukkit.Bukkit;
+import org.bukkit.event.HandlerList;
 import org.bukkit.permissions.Permission;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
@@ -60,7 +61,11 @@ public class BukkitWrapper extends JavaPlugin implements ChannelInitializeListen
     }
 
     @Override
-    public void onDisable() {}
+    public void onDisable() {
+        Bukkit.getMessenger().unregisterOutgoingPluginChannel(this, EMOTE_PACKET);
+        Bukkit.getMessenger().unregisterIncomingPluginChannel(this, EMOTE_PACKET);
+        HandlerList.unregisterAll(ServerSideEmotePlay.getInstance());
+    }
 
     @Override
     public void afterInitChannel(@NotNull Channel channel) {


### PR DESCRIPTION
UnsupportedOperationException will not protect it from being shipped in runtime, you don't even need to register it by hand, everything is done for you by the kernel, PlugMan does the same thing by the way.