### PR TITLE
Add direction-aware (PacketBound) sub-packet filtering

### DIFF
--- a/emotesAPI/src/main/java/io/github/kosmx/emotes/common/network/EmotePacket.java
+++ b/emotesAPI/src/main/java/io/github/kosmx/emotes/common/network/EmotePacket.java
@@ -48,21 +48,31 @@ public final class EmotePacket {
         this.data = data;
     }
 
-    public EmotePacket(@NotNull ByteBuf byteBuf) {
+    public EmotePacket(@NotNull ByteBuf byteBuf, PacketBound target) {
+        if (byteBuf.readableBytes() < 6) throw new RuntimeException("Invalid packet header");
         if (byteBuf.readInt() > CommonData.networkingVersion) throw new RuntimeException("Can't read newer version");
         this.data = new NetData();
         this.data.purpose = PacketTask.getTaskFromID(byteBuf.readByte());
 
         short count = byteBuf.readUnsignedByte();
         for (int i = 0; i < count; i++) {
+            if (byteBuf.readableBytes() < 6) {
+                throw new RuntimeException("Invalid sub-packet header");
+            }
+
             AbstractNetworkPacket packet = SUB_PACKETS.get(byteBuf.readByte());
             byte subVersion = byteBuf.readByte();
             int size = byteBuf.readInt();
             int currentPos = byteBuf.readerIndex();
 
-            if (packet != null) {
+            if (size < 0 || size > byteBuf.readableBytes()) {
+                throw new RuntimeException("Invalid sub-packet size: " + size);
+            }
+
+            if (packet != null && packet.boundsTo().contains(target)) {
                 try {
-                    packet.read(byteBuf, this.data, subVersion);
+                    // Slice to the sub-packet boundary so a reader can't run past its own data
+                    packet.read(byteBuf.slice(currentPos, size), this.data, subVersion);
                 } catch (Throwable th) {
                     if (packet.isOptional()) {
                         CommonData.LOGGER.warn("Invalid {} sub-packet received!", packet, th);
@@ -70,13 +80,9 @@ public final class EmotePacket {
                         throw new RuntimeException("Invalid " + packet + " sub-packet received", th);
                     }
                 }
-
-                if (byteBuf.readerIndex() != size + currentPos) {
-                    byteBuf.readerIndex(currentPos + size);
-                }
-            } else {
-                byteBuf.readerIndex(currentPos + size);
             }
+
+            byteBuf.readerIndex(currentPos + size);
         }
 
         if (!data.prepareAndValidate()) throw new RuntimeException("no valid data");
@@ -85,7 +91,7 @@ public final class EmotePacket {
     /**
      * Write packet to a ByteBuf.
      */
-    public void write(ByteBuf buf) {
+    public void write(ByteBuf buf, PacketBound target) {
         if (data.purpose == PacketTask.UNKNOWN) throw new IllegalArgumentException("Can't send packet without any purpose...");
 
         int packetStart = buf.writerIndex();
@@ -99,7 +105,7 @@ public final class EmotePacket {
         int count = 0;
         try {
             for (AbstractNetworkPacket packet : SUB_PACKETS.values()) {
-                if (!packet.doWrite(this.data)) continue;
+                if (!packet.doWrite(this.data) || !packet.boundsTo().contains(target)) continue;
                 boolean optional = packet.isOptional();
 
                 int subPacketStart = buf.writerIndex();

--- a/emotesAPI/src/main/java/io/github/kosmx/emotes/common/network/PacketBound.java
+++ b/emotesAPI/src/main/java/io/github/kosmx/emotes/common/network/PacketBound.java
@@ -1,0 +1,14 @@
+package io.github.kosmx.emotes.common.network;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
+public enum PacketBound {
+    SERVER,
+    CLIENT;
+
+    public static final Set<PacketBound> BOTH = Collections.unmodifiableSet(EnumSet.allOf(PacketBound.class));
+    public static final Set<PacketBound> TO_CLIENT = Collections.unmodifiableSet(EnumSet.of(PacketBound.CLIENT));
+    public static final Set<PacketBound> TO_SERVER = Collections.unmodifiableSet(EnumSet.of(PacketBound.SERVER));
+}

--- a/emotesAPI/src/main/java/io/github/kosmx/emotes/common/network/objects/AbstractNetworkPacket.java
+++ b/emotesAPI/src/main/java/io/github/kosmx/emotes/common/network/objects/AbstractNetworkPacket.java
@@ -1,9 +1,11 @@
 package io.github.kosmx.emotes.common.network.objects;
 
+import io.github.kosmx.emotes.common.network.PacketBound;
 import io.netty.buffer.ByteBuf;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Set;
 
 public abstract class AbstractNetworkPacket {
     public abstract byte getID();
@@ -21,5 +23,9 @@ public abstract class AbstractNetworkPacket {
 
     public boolean isOptional() {
         return false;
+    }
+
+    public Set<PacketBound> boundsTo() {
+        return PacketBound.BOTH;
     }
 }

--- a/emotesAPI/src/main/java/io/github/kosmx/emotes/common/network/objects/EmoteHeaderPacket.java
+++ b/emotesAPI/src/main/java/io/github/kosmx/emotes/common/network/objects/EmoteHeaderPacket.java
@@ -1,10 +1,12 @@
 package io.github.kosmx.emotes.common.network.objects;
 
+import io.github.kosmx.emotes.common.network.PacketBound;
 import io.github.kosmx.emotes.common.network.CommonNetwork;
 import io.github.kosmx.emotes.common.network.PacketConfig;
 import io.netty.buffer.ByteBuf;
 
 import java.util.List;
+import java.util.Set;
 
 public class EmoteHeaderPacket extends AbstractNetworkPacket{
     @Override
@@ -44,5 +46,10 @@ public class EmoteHeaderPacket extends AbstractNetworkPacket{
     @Override
     public boolean doWrite(NetData config) {
         return config.emoteData != null && config.purpose.exchangeHeader;
+    }
+
+    @Override
+    public Set<PacketBound> boundsTo() {
+        return PacketBound.TO_CLIENT;
     }
 }

--- a/emotesAPI/src/main/java/io/github/kosmx/emotes/common/network/objects/EmoteIconPacket.java
+++ b/emotesAPI/src/main/java/io/github/kosmx/emotes/common/network/objects/EmoteIconPacket.java
@@ -1,10 +1,13 @@
 package io.github.kosmx.emotes.common.network.objects;
 
+import io.github.kosmx.emotes.common.network.PacketBound;
 import io.github.kosmx.emotes.common.network.PacketConfig;
 import io.github.kosmx.emotes.common.network.PacketTask;
 import io.netty.buffer.ByteBuf;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Set;
 
 public class EmoteIconPacket extends AbstractNetworkPacket{
     @Override
@@ -18,9 +21,17 @@ public class EmoteIconPacket extends AbstractNetworkPacket{
     }
 
     @Override
-    public void read(ByteBuf byteBuf, NetData config, byte version) {
+    public void read(ByteBuf byteBuf, NetData config, byte version) throws IOException {
+        if (byteBuf.readableBytes() < Integer.BYTES) {
+            throw new IOException("Invalid icon packet: missing size");
+        }
+
         int size = byteBuf.readInt();
         if (size <= 0) return;
+
+        if (size > byteBuf.readableBytes()) {
+            throw new IOException("Invalid icon packet size: " + size);
+        }
 
         ByteBuffer buffer = ByteBuffer.allocate(size);
         byteBuf.readBytes(buffer);
@@ -50,5 +61,10 @@ public class EmoteIconPacket extends AbstractNetworkPacket{
     @Override
     public boolean isOptional() {
         return true;
+    }
+
+    @Override
+    public Set<PacketBound> boundsTo() {
+        return PacketBound.TO_CLIENT;
     }
 }

--- a/emotesAPI/src/test/java/io/github/kosmx/emotes/testing/common/NetworkPacketTest.java
+++ b/emotesAPI/src/test/java/io/github/kosmx/emotes/testing/common/NetworkPacketTest.java
@@ -2,6 +2,7 @@ package io.github.kosmx.emotes.testing.common;
 
 import com.zigythebird.playeranimcore.animation.Animation;
 import io.github.kosmx.emotes.common.network.EmotePacket;
+import io.github.kosmx.emotes.common.network.PacketBound;
 import io.github.kosmx.emotes.common.network.objects.NetData;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -26,12 +27,12 @@ public class NetworkPacketTest {
             builder.setVersion(EmotePacket.defaultVersions);
             builder.configureToStreamEmote(pair.left());
             ByteBuf buf = Unpooled.buffer();
-            builder.build().write(buf);
+            builder.build().write(buf, PacketBound.CLIENT);
 
             //The array has been sent, hope, it will arrive correctly.
             //Assume it has happened, create a new ByteBuffer and read it.
 
-            NetData data = new EmotePacket(buf).data; //That read expression is kinda funny
+            NetData data = new EmotePacket(buf, PacketBound.CLIENT).data; //That read expression is kinda funny
             Assertions.assertNotNull(data, "Data should be not null");
             Assertions.assertEquals(pair.left().boneAnimations(), data.emoteData.boneAnimations(), "The received data should contain the same emote");
             Assertions.assertEquals(pair.left().boneAnimations().hashCode(), data.emoteData.boneAnimations().hashCode(), "The received data should contain the same emote");
@@ -43,12 +44,12 @@ public class NetworkPacketTest {
             EmotePacket.Builder builder = new EmotePacket.Builder();
             builder.configureToSendStop(randID);
             ByteBuf buf = Unpooled.buffer();
-            builder.build().write(buf);
+            builder.build().write(buf, PacketBound.CLIENT);
 
             //The array has been sent, hope, it will arrive correctly.
             //Assume it has happened, create a new ByteBuffer and read it.
 
-            NetData data = new EmotePacket(buf).data;
+            NetData data = new EmotePacket(buf, PacketBound.CLIENT).data;
             Assertions.assertEquals(randID, data.stopEmoteID);
         }
 
@@ -59,12 +60,12 @@ public class NetworkPacketTest {
             builder.configureToSendStop(randID);
             builder.configureToStreamEmote(pair.left());
             ByteBuf buf = Unpooled.buffer();
-            builder.build().write(buf);
+            builder.build().write(buf, PacketBound.CLIENT);
 
             //The array has been sent, hope, it will arrive correctly.
             //Assume it has happened, create a new ByteBuffer and read it.
 
-            NetData data = new EmotePacket(buf).data;
+            NetData data = new EmotePacket(buf, PacketBound.CLIENT).data;
             shouldRemainFalse = true; //That line should not bu used
         }catch (Exception ignored){
 

--- a/emotesAPI/src/test/java/io/github/kosmx/emotes/testing/common/NetworkPacketTest.java
+++ b/emotesAPI/src/test/java/io/github/kosmx/emotes/testing/common/NetworkPacketTest.java
@@ -72,4 +72,32 @@ public class NetworkPacketTest {
         }
         Assertions.assertFalse(shouldRemainFalse, "Writer didn't thrown exception");
     }
+
+    @Test
+    @DisplayName("PacketBound directional filtering")
+    public void boundTest() {
+        Animation emote = RandomEmoteData.generateEmotes().left();
+
+        // A FILE emote carries the header sub-packet, which is bound TO_CLIENT only.
+        EmotePacket packet = new EmotePacket.Builder()
+                .strictSizeLimit(false).configureToSaveEmote(emote).build();
+
+        ByteBuf client = Unpooled.buffer();
+        packet.write(client, PacketBound.CLIENT);
+        ByteBuf server = Unpooled.buffer();
+        packet.write(server, PacketBound.SERVER);
+
+        // Write side: the TO_CLIENT header is emitted only towards the client.
+        Assertions.assertTrue(client.readableBytes() > server.readableBytes(),
+                "Client-bound packet must include the TO_CLIENT header sub-packet");
+
+        // Read side: both directions decode to a valid emote, and reading a client-bound
+        // packet as the server skips the header sub-packet instead of choking on it.
+        Assertions.assertNotNull(new EmotePacket(client.duplicate(), PacketBound.CLIENT).data.emoteData);
+        Assertions.assertNotNull(new EmotePacket(client.duplicate(), PacketBound.SERVER).data.emoteData);
+        Assertions.assertNotNull(new EmotePacket(server.duplicate(), PacketBound.SERVER).data.emoteData);
+
+        client.release();
+        server.release();
+    }
 }

--- a/emotesServer/src/main/java/io/github/kosmx/emotes/server/network/AbstractServerEmotePlay.java
+++ b/emotesServer/src/main/java/io/github/kosmx/emotes/server/network/AbstractServerEmotePlay.java
@@ -7,6 +7,7 @@ import io.github.kosmx.emotes.api.events.server.ServerEmoteEvents;
 import io.github.kosmx.emotes.api.proxy.AbstractNetworkInstance;
 import io.github.kosmx.emotes.common.CommonData;
 import io.github.kosmx.emotes.common.network.EmotePacket;
+import io.github.kosmx.emotes.common.network.PacketBound;
 import io.github.kosmx.emotes.common.network.PacketConfig;
 import io.github.kosmx.emotes.common.network.objects.NetData;
 import io.github.kosmx.emotes.server.config.Serializer;
@@ -31,7 +32,7 @@ public abstract class AbstractServerEmotePlay<P extends IServerNetworkInstance> 
     protected abstract P getPlayerFromUUID(UUID player);
 
     public void receiveMessage(ByteBuf bytes, P instance) throws IOException {
-        receiveMessage(new EmotePacket(bytes), instance);
+        receiveMessage(new EmotePacket(bytes, PacketBound.SERVER), instance);
     }
 
     @SuppressWarnings("deprecation")

--- a/emotesServer/src/main/java/io/github/kosmx/emotes/server/serializer/type/impl/BinaryFormat.java
+++ b/emotesServer/src/main/java/io/github/kosmx/emotes/server/serializer/type/impl/BinaryFormat.java
@@ -2,6 +2,7 @@ package io.github.kosmx.emotes.server.serializer.type.impl;
 
 import com.zigythebird.playeranimcore.animation.Animation;
 import io.github.kosmx.emotes.common.network.EmotePacket;
+import io.github.kosmx.emotes.common.network.PacketBound;
 import io.github.kosmx.emotes.common.network.PacketTask;
 import io.github.kosmx.emotes.common.network.objects.NetData;
 import io.github.kosmx.emotes.server.serializer.type.EmoteSerializerException;
@@ -22,7 +23,7 @@ public class BinaryFormat implements IReader, IWriter {
         try {
             buf.writeBytes(stream.readAllBytes());
 
-            NetData data = new EmotePacket(buf).data;
+            NetData data = new EmotePacket(buf, PacketBound.CLIENT).data;
             if (data.purpose != PacketTask.FILE || data.emoteData == null) {
                 throw new EmoteSerializerException("Binary emote is invalid", getExtension());
             }
@@ -38,7 +39,7 @@ public class BinaryFormat implements IReader, IWriter {
     public void write(Animation emote, OutputStream stream, String filename) throws EmoteSerializerException {
         ByteBuf buf = ByteBufAllocator.DEFAULT.buffer();
         try {
-            new EmotePacket.Builder().strictSizeLimit(false).configureToSaveEmote(emote).build().write(buf);
+            new EmotePacket.Builder().strictSizeLimit(false).configureToSaveEmote(emote).build().write(buf, PacketBound.CLIENT);
             buf.readBytes(stream, buf.readableBytes());
         } catch (Throwable e){
             throw new EmoteSerializerException("Something went wrong", getExtension(), e);

--- a/geyser/src/main/java/org/redlance/dima_dencep/mods/emotecraft/geyser/EmotecraftExt.java
+++ b/geyser/src/main/java/org/redlance/dima_dencep/mods/emotecraft/geyser/EmotecraftExt.java
@@ -4,6 +4,7 @@ import com.zigythebird.playeranimcore.animation.Animation;
 import io.github.kosmx.emotes.common.CommonData;
 import io.github.kosmx.emotes.common.SerializableConfig;
 import io.github.kosmx.emotes.common.network.EmotePacket;
+import io.github.kosmx.emotes.common.network.PacketBound;
 import io.github.kosmx.emotes.common.tools.MathHelper;
 import io.github.kosmx.emotes.server.config.ConfigSerializer;
 import io.github.kosmx.emotes.server.config.Serializer;
@@ -152,8 +153,13 @@ public class EmotecraftExt implements Extension {
             networkInstance.setConnectionType(ConnectionType.BACKEND);
         }
         ByteBuf byteBuf = Unpooled.wrappedBuffer(bytes);
-        networkInstance.receiveMessage(new EmotePacket(byteBuf));
-        byteBuf.release();
+        try {
+            networkInstance.receiveMessage(new EmotePacket(byteBuf, PacketBound.CLIENT));
+        } catch (Exception e) {
+            CommonData.LOGGER.error("Invalid Emotecraft packet!", e);
+        } finally {
+            byteBuf.release();
+        }
     }
 
     @Subscribe

--- a/geyser/src/main/java/org/redlance/dima_dencep/mods/emotecraft/geyser/handler/GeyserNetworkInstance.java
+++ b/geyser/src/main/java/org/redlance/dima_dencep/mods/emotecraft/geyser/handler/GeyserNetworkInstance.java
@@ -6,6 +6,7 @@ import io.github.kosmx.emotes.api.events.client.ClientEmoteEvents;
 import io.github.kosmx.emotes.api.proxy.AbstractNetworkInstance;
 import io.github.kosmx.emotes.common.CommonData;
 import io.github.kosmx.emotes.common.network.EmotePacket;
+import io.github.kosmx.emotes.common.network.PacketBound;
 import io.github.kosmx.emotes.common.network.PacketConfig;
 import io.github.kosmx.emotes.common.network.objects.NetData;
 import io.github.kosmx.emotes.common.tools.MathHelper;
@@ -63,7 +64,7 @@ public class GeyserNetworkInstance extends AbstractNetworkInstance {
     public void sendMessage(EmotePacket packet, @Nullable UUID target) {
         ByteBuf buf = ByteBufAllocator.DEFAULT.buffer();
         try {
-            packet.write(buf);
+            packet.write(buf, PacketBound.SERVER);
             ((GeyserSession) this.session).sendDownstreamPacket(new ServerboundCustomPayloadPacket(
                     EmotecraftExt.EMOTECRAFT_EMOTE_TYPE, MathHelper.readBytes(buf)
             ));

--- a/minecraft/archCommon/src/main/java/io/github/kosmx/emotes/arch/network/EmotePacketPayload.java
+++ b/minecraft/archCommon/src/main/java/io/github/kosmx/emotes/arch/network/EmotePacketPayload.java
@@ -1,6 +1,7 @@
 package io.github.kosmx.emotes.arch.network;
 
 import io.github.kosmx.emotes.common.network.EmotePacket;
+import io.github.kosmx.emotes.common.network.PacketBound;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
@@ -20,11 +21,30 @@ public record EmotePacketPayload(@NotNull CustomPacketPayload.Type<?> id, @NotNu
         return new EmotePacketPayload(NetworkPlatformTools.STREAM_CHANNEL_ID, packet);
     }
 
+    /**
+     * A codec for a single physical direction. The {@code bound} (the packet's destination endpoint)
+     * is used for BOTH encoding and decoding, so the writer and reader always filter the same
+     * sub-packet set. S2C ⇒ {@link PacketBound#CLIENT}, C2S ⇒ {@link PacketBound#SERVER}.
+     */
     @NotNull
-    public static StreamCodec<FriendlyByteBuf, EmotePacketPayload> reader(@NotNull CustomPacketPayload.Type<?> channel) {
-        return CustomPacketPayload.codec((payload, buf) -> payload.packet().write(buf), buf -> new EmotePacketPayload(channel, new EmotePacket(buf)));
+    public static StreamCodec<FriendlyByteBuf, EmotePacketPayload> reader(@NotNull CustomPacketPayload.Type<?> channel, PacketBound bound) {
+        return CustomPacketPayload.codec(
+                (payload, buf) -> payload.packet().write(buf, bound),
+                buf -> new EmotePacketPayload(channel, new EmotePacket(buf, bound))
+        );
     }
 
-    public static final StreamCodec<FriendlyByteBuf, EmotePacketPayload> EMOTE_CHANNEL_READER = reader(NetworkPlatformTools.EMOTE_CHANNEL_ID);
-    public static final StreamCodec<FriendlyByteBuf, EmotePacketPayload> STREAM_CHANNEL_READER = reader(NetworkPlatformTools.STREAM_CHANNEL_ID);
+    public static final StreamCodec<FriendlyByteBuf, EmotePacketPayload> EMOTE_CHANNEL_READER_S2C = reader(
+            NetworkPlatformTools.EMOTE_CHANNEL_ID, PacketBound.CLIENT
+    );
+    public static final StreamCodec<FriendlyByteBuf, EmotePacketPayload> EMOTE_CHANNEL_READER_C2S = reader(
+            NetworkPlatformTools.EMOTE_CHANNEL_ID, PacketBound.SERVER
+    );
+
+    public static final StreamCodec<FriendlyByteBuf, EmotePacketPayload> STREAM_CHANNEL_READER_S2C = reader(
+            NetworkPlatformTools.STREAM_CHANNEL_ID, PacketBound.CLIENT
+    );
+    public static final StreamCodec<FriendlyByteBuf, EmotePacketPayload> STREAM_CHANNEL_READER_C2S = reader(
+            NetworkPlatformTools.STREAM_CHANNEL_ID, PacketBound.SERVER
+    );
 }

--- a/minecraft/archCommon/src/main/java/io/github/kosmx/emotes/arch/network/NetworkPlatformTools.java
+++ b/minecraft/archCommon/src/main/java/io/github/kosmx/emotes/arch/network/NetworkPlatformTools.java
@@ -39,4 +39,21 @@ public interface NetworkPlatformTools {
     static @NotNull Packet<?> streamPacket(@NotNull EmotePacket packet) {
         return createClientboundPacket(STREAM_CHANNEL_ID, packet);
     }
+
+    @FunctionalInterface
+    interface PacketReceiver {
+        void receive() throws Exception;
+    }
+
+    /**
+     * Runs a packet receiver, logging (instead of propagating) any failure so a malformed
+     * packet can't take down the connection handler.
+     */
+    static void tryReceive(@NotNull PacketReceiver receiver) {
+        try {
+            receiver.receive();
+        } catch (Exception e) {
+            CommonData.LOGGER.error("Invalid Emotecraft packet!", e);
+        }
+    }
 }

--- a/minecraft/archCommon/src/main/java/io/github/kosmx/emotes/main/network/ClientEmotePlay.java
+++ b/minecraft/archCommon/src/main/java/io/github/kosmx/emotes/main/network/ClientEmotePlay.java
@@ -124,7 +124,7 @@ public class ClientEmotePlay extends ClientEmoteAPI {
                 break;
             case UNKNOWN:
             default:
-                CommonData.LOGGER.error("Packet execution is not possible unknown purpose");
+                CommonData.LOGGER.error("Packet execution is not possible: {} purpose!", data.purpose);
                 break;
         }
     }

--- a/minecraft/archCommon/src/main/java/io/github/kosmx/emotes/main/network/ClientEmotePlay.java
+++ b/minecraft/archCommon/src/main/java/io/github/kosmx/emotes/main/network/ClientEmotePlay.java
@@ -121,7 +121,9 @@ public class ClientEmotePlay extends ClientEmoteAPI {
                 break;
             case FILE:
                 EmoteHolder.addEmoteToList(data.emoteData, networkInstance);
+                break;
             case UNKNOWN:
+            default:
                 CommonData.LOGGER.error("Packet execution is not possible unknown purpose");
                 break;
         }

--- a/minecraft/fabric/src/main/java/io/github/kosmx/emotes/fabric/network/ClientNetworkInstance.java
+++ b/minecraft/fabric/src/main/java/io/github/kosmx/emotes/fabric/network/ClientNetworkInstance.java
@@ -2,34 +2,25 @@ package io.github.kosmx.emotes.fabric.network;
 
 import io.github.kosmx.emotes.arch.network.NetworkPlatformTools;
 import io.github.kosmx.emotes.arch.network.client.ClientNetwork;
-import io.github.kosmx.emotes.common.CommonData;
 import net.fabricmc.fabric.api.client.networking.v1.C2SPlayChannelEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientConfigurationNetworking;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
-
-import java.io.IOException;
 
 public class ClientNetworkInstance {
     @SuppressWarnings("deprecation")
     public static void init() {
         // Configuration
 
-        ClientConfigurationNetworking.registerGlobalReceiver(NetworkPlatformTools.EMOTE_CHANNEL_ID, (buf, context) -> {
-            try {
-                ClientNetwork.INSTANCE.receiveConfigMessage(buf.packet(), context.responseSender()::sendPacket);
-            } catch (IOException e) {
-                CommonData.LOGGER.error("", e);
-            }
-        });
+        ClientConfigurationNetworking.registerGlobalReceiver(NetworkPlatformTools.EMOTE_CHANNEL_ID, (buf, context) ->
+                NetworkPlatformTools.tryReceive(() ->
+                        ClientNetwork.INSTANCE.receiveConfigMessage(buf.packet(), context.responseSender()::sendPacket))
+        );
 
-        ClientConfigurationNetworking.registerGlobalReceiver(NetworkPlatformTools.STREAM_CHANNEL_ID, (buf, context) -> {
-            try {
-                ClientNetwork.INSTANCE.receiveStreamMessage(buf.packet(), context.responseSender()::sendPacket);
-            } catch (IOException e) {
-                CommonData.LOGGER.error("", e);
-            }
-        });
+        ClientConfigurationNetworking.registerGlobalReceiver(NetworkPlatformTools.STREAM_CHANNEL_ID, (buf, context) ->
+                NetworkPlatformTools.tryReceive(() ->
+                        ClientNetwork.INSTANCE.receiveStreamMessage(buf.packet(), context.responseSender()::sendPacket))
+        );
 
         // Play
         C2SPlayChannelEvents.REGISTER.register((handler, sender, minecraft, channels) -> {
@@ -43,12 +34,9 @@ public class ClientNetworkInstance {
                 (buf, context) -> ClientNetwork.INSTANCE.receiveMessage(buf.packet())
         );
 
-        ClientPlayNetworking.registerGlobalReceiver(NetworkPlatformTools.STREAM_CHANNEL_ID, (buf, context) -> {
-            try {
-                ClientNetwork.INSTANCE.receiveStreamMessage(buf.packet(), context.responseSender()::sendPacket);
-            } catch (IOException e) {
-                CommonData.LOGGER.error("", e);
-            }
-        });
+        ClientPlayNetworking.registerGlobalReceiver(NetworkPlatformTools.STREAM_CHANNEL_ID, (buf, context) ->
+                NetworkPlatformTools.tryReceive(() ->
+                        ClientNetwork.INSTANCE.receiveStreamMessage(buf.packet(), context.responseSender()::sendPacket))
+        );
     }
 }

--- a/minecraft/fabric/src/main/java/io/github/kosmx/emotes/fabric/network/PayloadTypeRegistator.java
+++ b/minecraft/fabric/src/main/java/io/github/kosmx/emotes/fabric/network/PayloadTypeRegistator.java
@@ -9,15 +9,15 @@ import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 
 public class PayloadTypeRegistator {
     public static void init() {
-        register(NetworkPlatformTools.EMOTE_CHANNEL_ID, EmotePacketPayload.EMOTE_CHANNEL_READER);
-        register(NetworkPlatformTools.STREAM_CHANNEL_ID, EmotePacketPayload.STREAM_CHANNEL_READER);
+        register(NetworkPlatformTools.EMOTE_CHANNEL_ID, EmotePacketPayload.EMOTE_CHANNEL_READER_S2C, EmotePacketPayload.EMOTE_CHANNEL_READER_C2S);
+        register(NetworkPlatformTools.STREAM_CHANNEL_ID, EmotePacketPayload.STREAM_CHANNEL_READER_S2C, EmotePacketPayload.STREAM_CHANNEL_READER_C2S);
     }
 
-    private static void register(CustomPacketPayload.Type<EmotePacketPayload> type, StreamCodec<FriendlyByteBuf, EmotePacketPayload> codec) {
-        PayloadTypeRegistry.configurationS2C().register(type, codec);
-        PayloadTypeRegistry.configurationC2S().register(type, codec);
+    private static void register(CustomPacketPayload.Type<EmotePacketPayload> type, StreamCodec<FriendlyByteBuf, EmotePacketPayload> s2c, StreamCodec<FriendlyByteBuf, EmotePacketPayload> c2s) {
+        PayloadTypeRegistry.configurationS2C().register(type, s2c);
+        PayloadTypeRegistry.configurationC2S().register(type, c2s);
 
-        PayloadTypeRegistry.playS2C().register(type, codec);
-        PayloadTypeRegistry.playC2S().register(type, codec);
+        PayloadTypeRegistry.playS2C().register(type, s2c);
+        PayloadTypeRegistry.playC2S().register(type, c2s);
     }
 }

--- a/minecraft/fabric/src/main/java/io/github/kosmx/emotes/fabric/network/ServerNetworkStuff.java
+++ b/minecraft/fabric/src/main/java/io/github/kosmx/emotes/fabric/network/ServerNetworkStuff.java
@@ -37,9 +37,9 @@ public final class ServerNetworkStuff {
                         .forEach(context.responseSender()::sendPacket);
 
                 context.networkHandler().completeTask(ConfigTask.TYPE); // And, we're done here
-            } catch (IOException e) {
-                CommonData.LOGGER.error("", e);
-                context.networkHandler().disconnect(Component.literal(CommonData.MOD_ID + ": " + e.getMessage()));
+            } catch (Exception e) {
+                CommonData.LOGGER.error("Invalid Emotecraft packet!", e);
+                context.networkHandler().disconnect(Component.literal(CommonData.MOD_ID + ": " + (e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName())));
             }
         });
 

--- a/minecraft/neoforge/src/main/java/io/github/kosmx/emotes/neoforge/network/ForgeNetwork.java
+++ b/minecraft/neoforge/src/main/java/io/github/kosmx/emotes/neoforge/network/ForgeNetwork.java
@@ -17,60 +17,61 @@ import java.io.IOException;
 public class ForgeNetwork {
     @SubscribeEvent
     public static void registerPlay(final RegisterPayloadHandlersEvent event) {
+        // A single StreamCodec can only filter for one direction, so each channel is registered
+        // per-direction: S2C codecs use PacketBound.CLIENT, C2S codecs use PacketBound.SERVER.
         event.registrar("emotecraft") // Play networking
                 .optional()
-                .playBidirectional(NetworkPlatformTools.EMOTE_CHANNEL_ID, EmotePacketPayload.EMOTE_CHANNEL_READER,
-                        (arg, playPayloadContext) -> CommonServerNetworkHandler.getInstance().receiveMessage(arg.packet(), playPayloadContext.player()),
-                        (arg, playPayloadContext) -> ClientNetwork.INSTANCE.receiveMessage(arg.packet())
+                .playToServer(NetworkPlatformTools.EMOTE_CHANNEL_ID, EmotePacketPayload.EMOTE_CHANNEL_READER_C2S,
+                        (arg, ctx) -> CommonServerNetworkHandler.getInstance().receiveMessage(arg.packet(), ctx.player())
+                )
+                .optional()
+                .playToClient(NetworkPlatformTools.EMOTE_CHANNEL_ID, EmotePacketPayload.EMOTE_CHANNEL_READER_S2C,
+                        (arg, ctx) -> ClientNetwork.INSTANCE.receiveMessage(arg.packet())
                 )
 
                 .optional()
-                .playBidirectional(NetworkPlatformTools.STREAM_CHANNEL_ID, EmotePacketPayload.STREAM_CHANNEL_READER,
-                        (arg, playPayloadContext) -> CommonServerNetworkHandler.getInstance().receiveStreamMessage(arg.packet(), playPayloadContext.player()),
-                        (arg, playPayloadContext) -> {
-                            try {
-                                ClientNetwork.INSTANCE.receiveStreamMessage(arg.packet(), playPayloadContext.listener()::send);
-                            } catch (IOException e) {
-                                CommonData.LOGGER.error("", e);
-                            }
-                        }
+                .playToServer(NetworkPlatformTools.STREAM_CHANNEL_ID, EmotePacketPayload.STREAM_CHANNEL_READER_C2S,
+                        (arg, ctx) -> CommonServerNetworkHandler.getInstance().receiveStreamMessage(arg.packet(), ctx.player())
+                )
+                .optional()
+                .playToClient(NetworkPlatformTools.STREAM_CHANNEL_ID, EmotePacketPayload.STREAM_CHANNEL_READER_S2C,
+                        (arg, ctx) -> NetworkPlatformTools.tryReceive(
+                                () -> ClientNetwork.INSTANCE.receiveStreamMessage(arg.packet(), ctx.listener()::send)
+                        )
                 )
 
                 .optional()
-                .configurationBidirectional(NetworkPlatformTools.EMOTE_CHANNEL_ID, EmotePacketPayload.EMOTE_CHANNEL_READER,
-                        (arg, configurationPayloadContext) -> {
+                .configurationToServer(NetworkPlatformTools.EMOTE_CHANNEL_ID, EmotePacketPayload.EMOTE_CHANNEL_READER_C2S,
+                        (arg, ctx) -> {
                             try {
                                 var message = arg.packet().data;
                                 if (message.purpose != PacketTask.CONFIG) throw new IOException("Wrong packet type for config task");
 
-                                ((EmotesMixinConnection) configurationPayloadContext.connection()).emotecraft$setVersions(message.versions);
+                                ((EmotesMixinConnection) ctx.connection()).emotecraft$setVersions(message.versions);
                                 UniversalEmoteSerializer.preparePackets(message.versions)
                                         .map(NetworkPlatformTools::playPacket)
-                                        .forEach(configurationPayloadContext.connection()::send);
+                                        .forEach(ctx.connection()::send);
 
-                                configurationPayloadContext.finishCurrentTask(ConfigTask.TYPE);
-                            } catch (IOException e) {
-                                CommonData.LOGGER.error("", e);
-                                configurationPayloadContext.disconnect(Component.literal(CommonData.MOD_ID + ": " + e.getMessage()));
-                            }
-                        },
-                        (arg, configurationPayloadContext) -> {
-                            try {
-                                ClientNetwork.INSTANCE.receiveConfigMessage(arg.packet(), configurationPayloadContext.listener()::send);
-                            } catch (IOException e) {
-                                CommonData.LOGGER.error("", e);
+                                ctx.finishCurrentTask(ConfigTask.TYPE);
+                            } catch (Exception e) {
+                                CommonData.LOGGER.error("Invalid Emotecraft packet!", e);
+                                ctx.disconnect(Component.literal(CommonData.MOD_ID + ": " + (e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName())));
                             }
                         }
                 )
+                .optional()
+                .configurationToClient(NetworkPlatformTools.EMOTE_CHANNEL_ID, EmotePacketPayload.EMOTE_CHANNEL_READER_S2C,
+                        (arg, ctx) -> NetworkPlatformTools.tryReceive(
+                                () -> ClientNetwork.INSTANCE.receiveConfigMessage(arg.packet(), ctx.listener()::send)
+                        )
+                )
 
                 .optional()
-                .configurationToClient(NetworkPlatformTools.STREAM_CHANNEL_ID, EmotePacketPayload.STREAM_CHANNEL_READER, (arg, configurationPayloadContext) -> {
-                    try {
-                        ClientNetwork.INSTANCE.receiveStreamMessage(arg.packet(), configurationPayloadContext.listener()::send);
-                    } catch (IOException e) {
-                        CommonData.LOGGER.error("", e);
-                    }
-                });
+                .configurationToClient(NetworkPlatformTools.STREAM_CHANNEL_ID, EmotePacketPayload.STREAM_CHANNEL_READER_S2C,
+                        (arg, ctx) -> NetworkPlatformTools.tryReceive(
+                                () -> ClientNetwork.INSTANCE.receiveStreamMessage(arg.packet(), ctx.listener()::send)
+                        )
+                );
     }
 
     @SubscribeEvent

--- a/paper/src/main/java/io/github/kosmx/emotes/bukkit/network/BukkitNetworkInstance.java
+++ b/paper/src/main/java/io/github/kosmx/emotes/bukkit/network/BukkitNetworkInstance.java
@@ -4,6 +4,7 @@ import io.github.kosmx.emotes.api.proxy.AbstractNetworkInstance;
 import io.github.kosmx.emotes.bukkit.BukkitWrapper;
 import io.github.kosmx.emotes.common.CommonData;
 import io.github.kosmx.emotes.common.network.EmotePacket;
+import io.github.kosmx.emotes.common.network.PacketBound;
 import io.github.kosmx.emotes.common.tools.MathHelper;
 import io.github.kosmx.emotes.server.network.EmotePlayTracker;
 import io.github.kosmx.emotes.server.network.IServerNetworkInstance;
@@ -38,7 +39,7 @@ public class BukkitNetworkInstance extends AbstractNetworkInstance implements IS
         }
         ByteBuf buf = ByteBufAllocator.DEFAULT.buffer();
         try {
-            packet.write(buf);
+            packet.write(buf, PacketBound.CLIENT);
             player.getBukkitEntity().sendPluginMessage(PLUGIN, BukkitWrapper.EMOTE_PACKET, MathHelper.readBytes(buf));
         } finally {
             buf.release();

--- a/paper/src/main/java/io/github/kosmx/emotes/bukkit/network/ServerSideEmotePlay.java
+++ b/paper/src/main/java/io/github/kosmx/emotes/bukkit/network/ServerSideEmotePlay.java
@@ -37,7 +37,7 @@ public final class ServerSideEmotePlay extends AbstractServerEmotePlay<BukkitNet
                 try {
                     this.receiveMessage(byteBuf, playerNetwork);
                 } catch (Exception e) {
-                    CommonData.LOGGER.error("", e);
+                    CommonData.LOGGER.error("Invalid Emotecraft packet from {}!", player.getName(), e);
                 } finally {
                     byteBuf.release();
                 }


### PR DESCRIPTION
Introduce PacketBound so header/icon sub-packets are only (de)serialized for their bound direction (TO_CLIENT), and route each network channel through a per-direction codec.

Networking:
- reader(channel, bound) uses one PacketBound for BOTH encode and decode, so writer and reader always filter the same sub-packet set. Codecs are named by direction: *_S2C (CLIENT), *_C2S (SERVER).
- Fabric: register S2C codecs into configurationS2C/playS2C and C2S codecs into configurationC2S/playC2S.
- NeoForge: replace the single-codec playBidirectional/configurationBidirectional with per-direction playToServer/playToClient/configurationToServer/ configurationToClient, so S2C encoding keeps the TO_CLIENT header/icon.

Robustness:
- EmotePacket: guard the packet header before reading, and hand each sub-packet a slice bounded to its own size so a reader can't run past it.
- Geyser receive path: wrap decode in try/catch/finally (log + release).
- Disconnect reason falls back to the exception class when message is null.

Cleanup:
- PacketBound.BOTH/TO_CLIENT/TO_SERVER are now unmodifiable Sets.
- Shared NetworkPlatformTools.tryReceive helper replaces duplicated catch-and-log blocks.
- Update NetworkPacketTest for the new EmotePacket(buf, bound) / write(buf, bound) signatures.

Closes #849