### PR TITLE
Add the Hytale server mod

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# Emotecraft
+
+Emotes for Minecraft and other block games. One shared animation engine, several platform frontends.
+
+## Conventions
+
+- **Agent files are written in English**, including this one. Conversations with the user may be in another
+  language, but anything committed to the repository is English.
+- Keep this file to general, slow-changing information. Anything long, detailed, or specific to one subproject goes in
+  the per-context files under `agents/`.
+- **Never write a fully qualified class name.** Not in code — import the type, even for a single use, and even where an
+  import would collide (import one and qualify nothing: rename or restructure instead). Not in prose either: these
+  files name types plainly, and a package path in a sentence dates the moment the class moves.
+- Match the surrounding code: same comment density, naming and idiom as the file being edited. Comments explain *why*,
+  never restate *what* the line already says.
+- Nullability annotations come from JetBrains, never from `javax.annotation` — including in code that overrides a
+  platform API annotated the other way.
+
+## Context files
+
+| File | Covers |
+|------|--------|
+| [agents/hytale.md](agents/hytale.md) | The Hytale server mod: asset formats, rig retargeting, emote delivery, UI |
+| [agents/emote-library.md](agents/emote-library.md) | The cloud emote library SDK and how each platform authorizes |
+
+## Modules
+
+Platform-independent core:
+
+- `emotesAPI` — the animation model and emote protocol. Depends on PlayerAnimationLib Core and NoteBlockLib.
+- `emotesServer` — emote (de)serialization, config and the service lookups every platform plugs into.
+- `emotesAssets` — shared resources, including the built-in emotes.
+- `emotesMc` — the Minecraft-specific half of the core.
+
+Platform frontends:
+
+- `minecraft` — the Fabric/NeoForge mod, built with Unimined. The reference implementation.
+- `paper` — the Paper/Folia plugin.
+- `geyser` — the Geyser extension, letting Bedrock clients see emotes.
+- `hytale` — the Hytale server mod. See [agents/hytale.md](agents/hytale.md).
+
+## Building
+
+Gradle, Kotlin DSL. Versions live in `gradle.properties`; helper functions in `buildSrc`. The whole project compiles
+against one Java version, set by `java_version`.
+
+Each frontend shades the core modules it needs, so a released artifact is self-contained. When a target runtime already
+ships a library, exclude it rather than shading a second copy.
+
+## Services
+
+The core resolves platform behaviour through a small service lookup: an interface in `emotesServer`, a default
+implementation with the lowest priority, and a platform implementation registered through `META-INF/services` at a
+higher priority. Anything a platform must answer differently — where the game directory is, how permissions work —
+goes through that mechanism rather than through conditionals in shared code.

--- a/agents/emote-library.md
+++ b/agents/emote-library.md
@@ -1,0 +1,61 @@
+# The cloud emote library
+
+A hosted library of emotes players can like on the website and then use in game, reached through a small SDK
+(`game-sdk`). The Minecraft client's implementation under the mod's library package is the reference to follow.
+
+## Shape of the API
+
+One client object wraps one **player's** session: the liked list and search both return that account's own likes. A
+server therefore needs a client per player, not one per server.
+
+Authorization is per platform, and each takes whatever proves ownership of an account on that platform: Minecraft
+answers a challenge through the session service, Bedrock presents its multiplayer token, Hytale its session-service
+identity token. Sessions expire on an idle window, so re-authorizing is a normal branch rather than an error path.
+
+Every call blocks except the live stream, which spins its own thread. None of them may run on a game thread.
+
+Errors are typed: ownership not proven, account not linked, session expired, no session, rate limited, download quota
+exceeded, network failure. Distinguish them — several are recoverable and one is fatal to the live stream.
+
+## Cost, and why laziness matters
+
+Three tiers, cheapest first:
+
+1. **Metadata** — one call per page of results. Carries name, description, author, tags and an icon URL, but no body.
+2. **Icon** — one HTTP fetch per emote actually shown.
+3. **Body** — the emote itself. This is the call under a **download quota**.
+
+Browsing must never touch tier 3. Fetch a body only when a player actually picks an emote, and only if it has not
+already been published — deduplicate on the publication, where the result is already recorded, rather than caching
+parsed animations that are useless once converted. Walking a player's whole liked list to fetch it up front is exactly
+what the quota is there to stop, whatever it would buy in convenience.
+
+Anywhere the converted form can be kept, keep it: a quota is spent per download, so an emote that survives a restart on
+disk is one that is never paid for twice. See the Hytale context file for how that plays out there.
+
+## Getting the token on Hytale
+
+The player's identity token is only ever visible on the packet that opens the connection; the login-phase handler
+keeps it private and is gone by the time a mod could ask. So it is read off that packet through the inbound packet
+adapter and kept, keyed weakly by connection, until the player's session needs it. Weakly, because there is no
+disconnect hook to clean up after and a player's credential should not outlive their session. It is never logged.
+
+## Text is Minecraft components
+
+Names, descriptions and authors arrive as **Minecraft component JSON**, not plain text — the Minecraft client feeds
+them straight through its component deserializer. Handing those strings to another game's label shows raw JSON.
+
+The two models line up closely: text and translation nodes, children, colour, bold and italic all have counterparts.
+Translation arguments do not: Minecraft substitutes positionally, most other systems by name.
+
+### Multiple fallbacks
+
+This is the one real divergence from vanilla Minecraft. Vanilla allows a translation node a single fallback; the
+library instead ships a **map of locale to text**. On Minecraft that needs a client mod, because components resolve
+client-side where the chosen language lives.
+
+Anywhere pages are built per player on the server, no such mod is needed: the viewer's own language selects the entry
+directly. Note the priority inverts, too. On a platform that has no Minecraft translation keys at all, the localized
+literal is the *only* thing that can be displayed, so the fallback is preferred outright and the key is a last resort
+rather than the first choice. Compare locale tags case-insensitively and normalise the separator, since platforms
+disagree on whether it is a dash or an underscore.

--- a/agents/hytale.md
+++ b/agents/hytale.md
@@ -1,0 +1,200 @@
+# The `hytale` subproject
+
+A Hytale **server** mod. Hytale exposes no client modding API, so everything here runs server-side and drives stock
+clients.
+
+## Research sources
+
+Hytale's full server source and every game asset ship in `hytale-shared-source-release.zip` (~1.4 GB, ~80k files),
+normally in the user's `Downloads`. Server sources are under `HytaleServer/`, assets under `HytaleAssets/`, the packet
+schema (C# definitions) under `Protocol/`. **Never unpack the whole archive** — list with `unzip -l | grep` and extract
+single files with `unzip -o -q -j <zip> "<path>" -d <dir>`.
+
+Prefer that archive over decompiling the published `Server` artifact. Only the server is published to Hytale's Maven —
+the client and the assets are not. Client sources are in neither, so anything the client alone interprets has to be
+inferred from the assets it reads.
+
+The MCP documentation server is a decent index but lags the archive: it was built against an older server and is
+missing, among other things, the runtime emote registration API. **When the docs and the archive disagree, the archive
+wins.** The docs' packet list is also truncated and omits the client-to-server emote packet.
+
+## Platform constraints
+
+- The server is compiled for the **same Java version as this project**, despite documentation claiming an older one.
+  No bytecode downgrade step is needed, unlike the Geyser frontend.
+- **The server bundles no SLF4J.** The core logs through SLF4J, so this module shades the API plus the JDK binding,
+  which lands on the JDK's built-in logging — the same sink Hytale's own logger writes to.
+- Asset and animation formats are all **JSON**, not binary.
+- Commands, UI callbacks and anything touching entity components run on a **world thread**. Blocking it freezes the
+  world's tick. Push blocking work onto another thread and hop back with the world's executor.
+
+## Emote delivery
+
+There is **no per-bone channel** to stream a live pose over, and Hytale's animation format has no expression language
+to parameterise — unlike Bedrock's Molang, which is exactly what lets the Geyser frontend drive bones through entity
+properties. The only way to show an arbitrary pose is to hand the client a finished keyframe clip.
+
+So the pipeline is: run the Emotecraft engine over an emote, sample the resulting pose, serialise it as a Hytale
+animation clip, register that clip plus an icon as *common assets*, then register an *emote asset* pointing at both.
+Registering the emote asset broadcasts an update — metadata only, not the blobs — and the emote becomes playable,
+including from the client's own emote wheel, which is built from the built-in list plus everything in the emote asset
+store. There is no "add to wheel" call and none is needed; slot assignment is client-side and the server can neither
+read nor set it.
+
+Two constraints the validators enforce: the animation must sit under the characters directory with the animation
+extension, and the icon under the emote icon directory as a PNG. Both must already be registered as common assets
+before the emote asset is registered, or validation fails.
+
+### Registration is in memory, delivery is ours
+
+Registration only mutates maps in the running server, so everything published is lost on restart — which is what the
+disk cache below exists to undo.
+
+The convenience registration call is unusable at this scale: it **broadcasts every asset to every connected player**
+with no distance or visibility check, announces each one with a toast to the whole server, and grows the list of assets
+every future login must download. The low-level registry call sends nothing at all, so registration and delivery are
+separated — register through the registry, then send the blobs to exactly the clients that need them.
+
+Who needs what follows from what each blob is for:
+
+- The **icon** is drawn by the emote wheel, which lists every registered emote for every player, so every player needs
+  every icon. They are small, and they go out once the client reports itself ready — not on connect, which would land
+  in the middle of the client's own asset phase.
+- The **clip** is only needed by someone about to watch the emote. That set is exactly the set the animation packet
+  itself is written to, and the server already has a helper for it, so an emote and the clip it needs reach the same
+  clients by construction. Going through the entity tracker's visibility index directly would be the same answer with
+  more code; the helper follows it if the core ever switches which side of the relation it reads.
+
+Nothing is sent to a connection twice, tracked weakly so a disconnect forgets it — the next connection is a new client
+that may have kept nothing.
+
+Because delivery is ours, the login-time required-asset list never mentions these blobs, and the client is never told
+to fetch them. That is the point: a player downloads a clip when somebody performs it in front of them, not a library's
+worth at every login.
+
+### Someone who arrives part-way through
+
+The animation packet is a one-shot write to whoever can see the performer at that instant; the core never replays it,
+and a TODO in the stop path admits as much. What it does have is a component meant for exactly this — "active animations
+on an entity so that looping animations are played when the entity comes into range" — whose system pushes an update to
+the newly-visible set every tick. It is documented as used only by NPCs so far, but nothing about it is NPC-specific,
+so an emote is recorded there as well as played.
+
+Recording it *and* playing it is not belt-and-braces, it is the core's own pattern: the NPC entity does both, and says
+why — "we also need to play the animation to all existing players since we only use the animation component for sending
+to new players."
+
+That update carries the animation id and nothing else, which leaves two gaps to fill locally:
+
+- The arrival needs the **clip** before the id reaches them. Our own system runs in the same group against the same
+  newly-visible set and writes the blobs straight to the connection, which puts them ahead of the core's update — that
+  one is merely queued in this group and flushed a group later.
+- Nothing would ever **end** the emote, so every future arrival would be shown a performance that finished long ago.
+  The clip's own length ends it, which is why the baker reports its frame count and the cache index keeps it.
+
+The performer's state — what is playing, until when, and the resolved blobs — lives in a component of ours on their
+entity. The blobs ride along because a viewer who has already appeared cannot be made to wait on a disk read, and they
+are let go the moment the emote ends. Cancelling an emote clears the same state; that packet still reaches the core,
+which stops the animation for everyone watching.
+
+**What cannot be done:** starting the clip at an offset. Neither the animation packet nor the active-animation update
+carries a time, and the emote asset has no offset or speed field, so someone who walks up mid-emote sees it **from the
+beginning** rather than from where it has got to. Emotecraft's other backends send the elapsed tick and resume in
+place; here the protocol has no field to put it in. Leaving the view and returning restarts it the same way.
+
+### Taking over the wheel
+
+An emote can be started from our page or from the client's own wheel, and the wheel path is a client-to-server packet
+handled by the core, which would play the emote against clients that may not hold the clip. So that packet is
+intercepted and cancelled **for our emotes only** — the blobs go out, then the animation plays. The stock handler is
+short and does nothing else of substance, which is what makes taking it over safe; everything that is not ours falls
+straight through to it.
+
+### The disk cache
+
+Baking is deterministic and downloading an emote body is the one thing the library charges for, so every emote that
+came from the library is written out next to an index of `emote UUID -> asset id` plus each blob's hash. Emotes that
+already live on disk in Emotecraft's own format — the built-in ones — are not cached: baking them is cheap, and an
+emote file that changes under an unchanged UUID would otherwise be served stale forever.
+
+At startup the whole cache is republished. That is the preload: a restart costs no downloads. Blobs stay on disk until
+a client actually needs one, since the file-backed asset keeps its bytes only weakly.
+
+The index carries the baker's version stamp. The retargeting constants below are unverified, and a cached clip has no
+record of the axes it was baked with, so **any change to the baker or the rig must bump that stamp** — a mismatch
+empties the directory instead of replaying stale poses. The same happens if the index is unreadable, since the blobs
+beside it cannot be addressed without it.
+
+## Retargeting the rig
+
+Both rigs express a pose as a delta from the rest pose, so no rest transform has to be folded in — only naming, scale
+and axis convention differ. `HytaleRig` owns all of it; `BlockyAnimBaker` only samples and serialises.
+
+The engine does **not** animate in Minecraft's model space. Its own bone table puts the origin at the feet, Y up, with
+the right arm on +X and the cape on +Z. Hytale mirrors both of those, so the conversion is a **half turn about Y**,
+not about X. Hytale is also the taller rig, so translations are scaled by the two rigs' proportions rather than by a
+plain unit conversion.
+
+Rotations are retargeted onto the **target's own joints**. The Emotecraft pivots land a fair distance from the
+matching Hytale sockets — its torso pivots at the neck rather than the chest — so honouring them would swing each part
+out of its socket and tear the skeleton. The one exception is the root bone, which has no socket to tear: there the
+pivot difference is compensated for, since it visibly changes a full-body lean.
+
+The engine already returns *local* per-bone transforms. The Geyser frontend composes parents itself because Bedrock's
+rig is flat; Hytale nests its skeleton and composes client-side, so nothing is pre-composed here.
+
+Limb bend is a single scalar in Emotecraft and a real joint in Hytale, so it is replayed as a rotation on the segment
+below. Held items map onto the hand attachment nodes, so an item follows the arm through the skeleton and stays
+visible. The cape maps onto the back attachment node with its pitch inverted, matching a correction the Geyser
+frontend applies to the same authoring quirk.
+
+**Unverified against a running client:** the euler order, the sign of bend, the proportional scale factor and the
+cape's pitch. Expect to calibrate these the first time an emote is watched in game.
+
+## Sampling, not transcription
+
+The clip is sampled frame by frame rather than transcribed keyframe for keyframe. Emotecraft keeps a separate keyframe
+list *per axis*, each with its own easing and expressions, while a Hytale keyframe carries one whole vector and knows
+only two interpolation modes. Merging those axis timelines means evaluating them at every distinct time anyway.
+
+Runs where a node does not move collapse to the two keyframes that bound them. The trailing one is not a size saving:
+interpolation is linear, so a node holding still would otherwise drift across the whole span instead of staying put.
+
+## UI
+
+Pages are built server-side and pushed whole; there is no data binding, and the declarative data-context commands
+visible in the packet schema are unimplemented — nothing in the server references them. Lists are a scrolling group
+filled by appending rows and addressing them by index, and there is **no pagination widget**: the server's own
+convention is a search box plus a hard result cap.
+
+Read the player's chosen text out of a field with a selector-valued event key, which the client resolves at the moment
+the event fires. Doing that on a button press avoids the update-acknowledgement gate, which silently drops incoming
+events while an update is still in flight — the reason a search that reacts to every keystroke loses characters.
+
+Rebuilding a list means re-registering its event bindings, since they are bound to index selectors that now point at
+new elements.
+
+Text coming from the emote library is **Minecraft component JSON**, not plain text. `McComponents` converts it; see
+[emote-library.md](emote-library.md) for the fallback handling that matters there.
+
+## Keybindings
+
+A server mod **cannot** register one. The client feature registry takes a closed enum of gameplay toggles, and the
+hotkey UI element only draws an existing client binding. Key events reach the server only through bindings inside an
+open custom page, where the key itself cannot be chosen, and the HUD layer carries no event bindings at all.
+
+In practice this does not matter: the emote wheel's own hotkey already works with emotes this mod registers.
+
+## Still to do
+
+- An emote published while players are online reaches their wheels as metadata immediately, but its icon only when they
+  browse it or watch it performed. Until then that one row draws a placeholder.
+- Whether the client honours an active-animation update on a *player* entity is unproven. The channel itself is
+  entity-generic — a network id and a list of component updates — and demonstrably works for players, since skins are
+  synced over it. What no server-side source can settle is whether the client's handler for this particular update type
+  applies it to a player. If it does not, arriving part-way through shows nothing, and the protocol offers no
+  alternative.
+- Whether a client that receives a clip and the animation packet back to back processes them in that order is unproven.
+  If not, the first performance of an emote may be dropped by onlookers and only work from the second onwards.
+- The page markup and its path have never been loaded by a real client.
+- Calibrate the retargeting constants listed above.

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,4 +34,6 @@ unimined.auth.storeCredentials=true
     noteblocklib_version = 3.2.1
     geyser_version = 2.11.0-SNAPSHOT
     commonutils_version = 1.2.8
-    redlanceemotes_version = 2.0.2
+    redlanceemotes_version = 2.1.2
+    hytale_version = 0.5.7
+    slf4j_version = 2.0.17

--- a/hytale/build.gradle.kts
+++ b/hytale/build.gradle.kts
@@ -1,0 +1,110 @@
+import me.modmuss50.mpp.ReleaseType
+
+plugins {
+    java
+    `maven-publish`
+    id("com.gradleup.shadow")
+    id("me.modmuss50.mod-publish-plugin")
+}
+
+base.archivesName = "${project["archives_base_name"]}-${name}-for-Hytale${project["hytale_version"]}"
+version = mod_version
+
+repositories {
+    maven("https://maven.hytale.com/release") {
+        name = "Hytale"
+        content {
+            includeGroup("com.hypixel.hytale")
+        }
+    }
+}
+
+val compileApi = configurations.register("compileApi").get()
+configurations.api.configure { extendsFrom(compileApi) }
+
+dependencies {
+    // Hytale Server 0.5.7 ships as Java 25 bytecode (major 69), matching this project's java_version.
+    compileOnly("com.hypixel.hytale:Server:${project["hytale_version"]}")
+
+    // The Emotecraft engine itself: emote (de)serialization, the keyframe model and playback maths.
+    compileApi(project(":emotesAssets"))
+    compileApi(project(":emotesServer"))
+
+    compileApi("org.redlance.emotecraftlibrary:game-sdk:${project["redlanceemotes_version"]}")
+
+    // The Hytale server ships no SLF4J at all, so CommonData.LOGGER would blow up with NoClassDefFoundError.
+    // Bundle the API together with the JDK binding, which lands on java.util.logging - the same sink Hytale's
+    // Flogger writes to, so Emotecraft's log lines end up in the regular server log.
+    compileApi("org.slf4j:slf4j-jdk14:${project["slf4j_version"]}")
+}
+
+tasks {
+    processResources {
+        // mod_description spans several lines, which would be raw newlines inside a JSON string literal - escape them
+        // so the generated manifest.json stays parseable.
+        val description = project["mod_description"].replace("\\", "\\\\").replace("\n", "\\n").replace("\"", "\\\"")
+
+        inputs.property("version", version)
+        inputs.property("description", description)
+
+        filesMatching("manifest.json") {
+            expand("version" to version, "description" to description)
+        }
+    }
+
+    shadowJar {
+        configurations = listOf(compileApi)
+        archiveClassifier.set("")
+        mergeServiceFiles()
+
+        relocate("team.unnamed.mocha", "io.github.kosmx.emotes.hytale.libs.mocha")
+    }
+
+    jar {
+        archiveClassifier.set("dev")
+    }
+
+    assemble {
+        dependsOn(shadowJar)
+    }
+}
+
+java {
+    withSourcesJar()
+}
+
+shadow {
+    addShadowVariantIntoJavaComponent = false
+}
+
+publishing {
+    publications {
+        register<MavenPublication>("mavenJava") {
+            artifactId = "emotesHytale"
+            from(components["java"])
+            withCustomPom("emotesHytale", "Hytale Emotecraft server mod")
+        }
+    }
+
+    repositories {
+        if (shouldPublishMaven) {
+            kosmxRepo(project)
+        } else {
+            mavenLocal()
+        }
+    }
+}
+
+publishMods {
+    // Only GitHub is wired up: Modrinth/CurseForge have no Hytale loader to publish under yet.
+    file.set(tasks.shadowJar.get().archiveFile)
+
+    type = ReleaseType./*of(releaseType)*/ALPHA // Force alpha
+    changelog = changes
+    dryRun = gradle.startParameter.isDryRun
+
+    github {
+        accessToken = providers.environmentVariable("GH_TOKEN")
+        parent(rootProject.tasks.named("publishGithub"))
+    }
+}

--- a/hytale/src/main/java/io/github/kosmx/emotes/hytale/EmotePlayback.java
+++ b/hytale/src/main/java/io/github/kosmx/emotes/hytale/EmotePlayback.java
@@ -1,0 +1,141 @@
+package io.github.kosmx.emotes.hytale;
+
+import com.hypixel.hytale.component.ComponentType;
+import com.hypixel.hytale.component.Ref;
+import com.hypixel.hytale.component.Store;
+import com.hypixel.hytale.protocol.AnimationSlot;
+import com.hypixel.hytale.protocol.packets.entities.PlayEmote;
+import com.hypixel.hytale.server.core.entity.AnimationUtils;
+import com.hypixel.hytale.server.core.io.adapter.PacketAdapters;
+import com.hypixel.hytale.server.core.io.adapter.PacketFilter;
+import com.hypixel.hytale.server.core.io.adapter.PlayerPacketFilter;
+import com.hypixel.hytale.server.core.modules.entity.component.ActiveAnimationComponent;
+import com.hypixel.hytale.server.core.universe.PlayerRef;
+import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
+import io.github.kosmx.emotes.hytale.asset.EmoteDelivery;
+import io.github.kosmx.emotes.hytale.bake.BlockyAnimBaker;
+import io.github.kosmx.emotes.hytale.entity.Emoting;
+
+/**
+ * Plays an Emotecraft emote, making sure everyone who will see it holds the clip first.
+ * <p>
+ * Two things start an emote: our own page, and the client's emote wheel — which lists every registered emote asset,
+ * ours included, and asks the server to play one over {@link PlayEmote}. The stock handler for that packet would play
+ * it against clients that may never have received the clip, so emotes of ours are taken over: the packet is cancelled,
+ * the blobs go out to the audience, and only then is the animation played. Everything else, including Hytale's own
+ * emotes, is left to the stock handler untouched.
+ */
+public final class EmotePlayback implements AutoCloseable {
+    private final HytaleEmoteRegistry registry;
+    private final EmoteDelivery delivery;
+    private final PacketFilter filter;
+
+    public EmotePlayback(HytaleEmoteRegistry registry, EmoteDelivery delivery) {
+        this.registry = registry;
+        this.delivery = delivery;
+        this.filter = PacketAdapters.registerInbound((PlayerPacketFilter) (player, packet) -> {
+            if (!(packet instanceof PlayEmote emote)) {
+                return false;
+            }
+
+            if (emote.emoteId == null || emote.emoteId.isEmpty()) {
+                // A cancelled emote. The core stops the animation itself, but only our own state knows that a late
+                // arrival must no longer be shown it, so that is cleared alongside - and the packet still passes.
+                stop(player);
+                return false;
+            }
+
+            if (this.registry.published(emote.emoteId) == null) {
+                return false;
+            }
+
+            play(player, emote.emoteId);
+            return true; // ours, and already handled
+        });
+    }
+
+    /**
+     * @param id the Hytale asset id of a published emote
+     */
+    public void play(PlayerRef player, String id) {
+        HytaleEmoteRegistry.Published emote = this.registry.published(id);
+        if (emote == null) {
+            return;
+        }
+
+        Ref<EntityStore> ref = player.getReference();
+        if (ref == null) {
+            return;
+        }
+
+        // Reading a cached clip off disk and driving the animation are both off-limits here - one blocks, the other
+        // touches components - so the blobs are resolved first and the rest hops onto the world thread.
+        Store<EntityStore> store = ref.getStore();
+        EmoteDelivery.resolve(emote.assets()).thenAccept(blobs -> store.getExternalData().getWorld().execute(() -> {
+            if (!ref.isValid()) {
+                return;
+            }
+
+            this.delivery.send(ref, store, blobs);
+            AnimationUtils.playAnimation(ref, AnimationSlot.Emote, null, id, true, store);
+
+            // The packet above only reaches whoever is watching right now. This is what carries the emote to anyone who
+            // shows up while it is still running: the core replays an entity's active animation to new viewers, and
+            // EmoteTrackerSystem puts the clip in their hands first and clears both once the emote is over.
+            active(ref, store).setPlayingAnimation(AnimationSlot.Emote, id);
+            emoting(ref, store).start(id, blobs, System.currentTimeMillis() + BlockyAnimBaker.duration(emote.frames()));
+        }));
+    }
+
+    /** Forgets whatever the player was performing, so nobody arriving later is shown it. */
+    public void stop(PlayerRef player) {
+        Ref<EntityStore> ref = player.getReference();
+        if (ref == null) {
+            return;
+        }
+
+        Store<EntityStore> store = ref.getStore();
+        store.getExternalData().getWorld().execute(() -> {
+            if (!ref.isValid()) {
+                return;
+            }
+
+            Emoting emoting = store.getComponent(ref, Emoting.getComponentType());
+            if (emoting == null || emoting.getId() == null) {
+                return;
+            }
+
+            emoting.stop();
+            ActiveAnimationComponent active = store.getComponent(ref, ActiveAnimationComponent.getComponentType());
+            if (active != null) {
+                active.setPlayingAnimation(AnimationSlot.Emote, null);
+            }
+        });
+    }
+
+    private static ActiveAnimationComponent active(Ref<EntityStore> ref, Store<EntityStore> store) {
+        ComponentType<EntityStore, ActiveAnimationComponent> type = ActiveAnimationComponent.getComponentType();
+        ActiveAnimationComponent component = store.getComponent(ref, type);
+        if (component == null) {
+            // Players are not given one: the core only puts it on NPCs, whose animations it drives itself.
+            component = new ActiveAnimationComponent();
+            store.putComponent(ref, type, component);
+        }
+        return component;
+    }
+
+    private static Emoting emoting(Ref<EntityStore> ref, Store<EntityStore> store) {
+        ComponentType<EntityStore, Emoting> type = Emoting.getComponentType();
+        Emoting component = store.getComponent(ref, type);
+        if (component == null) {
+            component = new Emoting();
+            store.putComponent(ref, type, component);
+        }
+        return component;
+    }
+
+    @Override
+    public void close() {
+        PacketAdapters.deregisterInbound(this.filter);
+    }
+}

--- a/hytale/src/main/java/io/github/kosmx/emotes/hytale/EmotecraftPlugin.java
+++ b/hytale/src/main/java/io/github/kosmx/emotes/hytale/EmotecraftPlugin.java
@@ -1,0 +1,110 @@
+package io.github.kosmx.emotes.hytale;
+
+import com.hypixel.hytale.component.Ref;
+import com.hypixel.hytale.server.core.event.events.player.PlayerReadyEvent;
+import com.hypixel.hytale.server.core.plugin.JavaPlugin;
+import com.hypixel.hytale.server.core.plugin.JavaPluginInit;
+import com.hypixel.hytale.server.core.universe.PlayerRef;
+import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
+import com.zigythebird.playeranimcore.animation.Animation;
+import io.github.kosmx.emotes.common.CommonData;
+import io.github.kosmx.emotes.hytale.asset.EmoteCache;
+import io.github.kosmx.emotes.hytale.asset.EmoteDelivery;
+import io.github.kosmx.emotes.hytale.commands.EmotecraftCommand;
+import io.github.kosmx.emotes.hytale.entity.EmoteTrackerSystem;
+import io.github.kosmx.emotes.hytale.entity.Emoting;
+import io.github.kosmx.emotes.hytale.library.EmoteLibrary;
+import io.github.kosmx.emotes.hytale.services.HytaleInstanceService;
+import io.github.kosmx.emotes.server.config.CommonConfig;
+import io.github.kosmx.emotes.server.config.ConfigSerializer;
+import io.github.kosmx.emotes.server.config.Serializer;
+import io.github.kosmx.emotes.server.serializer.UniversalEmoteSerializer;
+import io.github.kosmx.emotes.server.services.InstanceService;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.logging.Level;
+
+public class EmotecraftPlugin extends JavaPlugin {
+    private final EmoteDelivery delivery = new EmoteDelivery();
+
+    private HytaleEmoteRegistry registry;
+    private EmotePlayback playback;
+    private EmoteLibrary library;
+
+    public EmotecraftPlugin(@NotNull JavaPluginInit init) {
+        super(init);
+
+        // Before the config or the emote cache resolve any path, so both land in the plugin's own directory.
+        HytaleInstanceService.setDataDirectory(getDataDirectory());
+
+        // UniversalEmoteSerializer reads the config while running its static initialiser, so the config has to exist
+        // before that class is ever touched - otherwise loading the readers NPEs on Serializer.INSTANCE.
+        Serializer.INSTANCE = new Serializer<>(
+                new ConfigSerializer<>(CommonConfig::new, CommonConfig.staticConfigVersion), CommonConfig.class
+        );
+    }
+
+    @Override
+    protected void setup() {
+        UniversalEmoteSerializer.loadEmotes();
+
+        this.registry = new HytaleEmoteRegistry(new EmoteCache(InstanceService.INSTANCE.getCacheDirectory().resolve("emotes")));
+        this.playback = new EmotePlayback(this.registry, this.delivery);
+
+        // What is playing on whom, and the system that carries it to players who arrive part-way through.
+        Emoting.setComponentType(getEntityStoreRegistry().registerComponent(Emoting.class, Emoting::new));
+        getEntityStoreRegistry().registerSystem(new EmoteTrackerSystem(this.delivery));
+
+        // Registered here so the Connect watcher is in place before the first player finishes connecting - the identity
+        // token it needs is only ever visible on that packet.
+        this.library = new EmoteLibrary(getManifest().getVersion().toString(), getName());
+        getCommandRegistry().registerCommand(new EmotecraftCommand(this.library, this.registry, this.delivery, this.playback));
+
+        // The emote wheel lists every published emote for every player, so every player needs every icon. The clips
+        // behind them are the expensive half, and those go out only to the people who actually watch an emote.
+        // Waiting for ready rather than connect keeps these out of the client's own asset phase; a second firing costs
+        // nothing, since a connection is never sent the same blob twice.
+        // Global, because the ready event is keyed and we want it whatever the key is.
+        getEventRegistry().registerGlobal(PlayerReadyEvent.class, (PlayerReadyEvent event) -> {
+            Ref<EntityStore> ref = event.getPlayerRef();
+            PlayerRef player = ref.getStore().getComponent(ref, PlayerRef.getComponentType());
+            if (player != null) {
+                this.delivery.send(player, this.registry.icons());
+            }
+        });
+    }
+
+    @Override
+    protected void shutdown() {
+        if (this.playback != null) {
+            this.playback.close();
+        }
+        if (this.library != null) {
+            this.library.close();
+        }
+    }
+
+    @Override
+    protected void start() {
+        // Baking resolves common assets, so it has to wait until the asset stores are up - which start() guarantees.
+        // Nobody is online yet either, which is what makes this the right moment to bring the cache back: the blobs go
+        // out with the rest of the required assets at login instead of being pushed at whoever happens to be connected.
+        int published = this.registry.publishCached();
+
+        for (Animation emote : UniversalEmoteSerializer.getLoadedEmotes().values()) {
+            if (this.registry.register(emote) != null) {
+                published++;
+            }
+        }
+
+        getLogger().at(Level.INFO).log("%s published %d emotes, playable with /emote", CommonData.MOD_NAME, published);
+    }
+
+    public HytaleEmoteRegistry getRegistry() {
+        return this.registry;
+    }
+
+    public EmoteLibrary getLibrary() {
+        return this.library;
+    }
+}

--- a/hytale/src/main/java/io/github/kosmx/emotes/hytale/HytaleEmoteRegistry.java
+++ b/hytale/src/main/java/io/github/kosmx/emotes/hytale/HytaleEmoteRegistry.java
@@ -1,0 +1,264 @@
+package io.github.kosmx.emotes.hytale;
+
+import com.hypixel.hytale.assetstore.map.DefaultAssetMap;
+import com.hypixel.hytale.server.core.asset.common.CommonAsset;
+import com.hypixel.hytale.server.core.asset.common.CommonAssetRegistry;
+import com.hypixel.hytale.server.core.asset.common.asset.FileCommonAsset;
+import com.hypixel.hytale.server.core.cosmetics.EmoteAsset;
+import com.zigythebird.playeranimcore.animation.Animation;
+import io.github.kosmx.emotes.common.CommonData;
+import io.github.kosmx.emotes.hytale.asset.EmoteCache;
+import io.github.kosmx.emotes.hytale.asset.EmotecraftEmoteAsset;
+import io.github.kosmx.emotes.hytale.asset.MemoryCommonAsset;
+import io.github.kosmx.emotes.hytale.bake.BlockyAnimBaker;
+
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+/**
+ * Publishes Emotecraft emotes to Hytale clients as native emotes.
+ * <p>
+ * Everything happens at runtime and reaches players who are already connected: touching the emote asset store
+ * broadcasts {@code UpdateEmotes(AddOrUpdate)}, so an emote pulled from the cloud library becomes playable without a
+ * restart, a pack rebuild, or a client mod. That broadcast carries metadata only — the blobs behind it are handed out
+ * per client by {@code EmoteDelivery}.
+ * <p>
+ * None of that survives a shutdown, which is what {@link EmoteCache} is for: an emote is downloaded and baked once ever
+ * rather than once per boot.
+ */
+public final class HytaleEmoteRegistry {
+    /** Hytale validates that an emote's animation lives under {@code Characters/} and its icon under {@code Icons/Emotes/}. */
+    private static final String ANIMATION_DIR = "Characters/Animations/Emotecraft/";
+    private static final String ICON_DIR = "Icons/Emotes/";
+
+    /** A 1x1 transparent PNG, used when an emote carries no icon of its own - the {@code Icon} field is mandatory. */
+    private static final byte[] BLANK_ICON = Base64.getDecoder().decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+    );
+
+    /** An emote as the client will receive it: the clip it animates from, the icon its wheel draws, and how long it runs. */
+    public record Published(String id, CommonAsset animation, CommonAsset icon, int frames) {
+        public List<CommonAsset> assets() {
+            return List.of(this.animation, this.icon);
+        }
+    }
+
+    private final String packKey;
+    private final EmoteCache cache;
+    private final Map<UUID, String> registered = new ConcurrentHashMap<>();
+    private final Map<String, Published> published = new ConcurrentHashMap<>();
+
+    /** Publications still in flight, so two players picking the same emote at once cause one download, not two. */
+    private final Map<UUID, CompletableFuture<String>> publishing = new ConcurrentHashMap<>();
+
+    public HytaleEmoteRegistry(EmoteCache cache) {
+        this(DefaultAssetMap.DEFAULT_PACK_KEY, cache);
+    }
+
+    public HytaleEmoteRegistry(String packKey, EmoteCache cache) {
+        this.packKey = packKey;
+        this.cache = cache;
+    }
+
+    /**
+     * Makes a library emote playable, downloading it only if neither this run nor the cache has it already.
+     * <p>
+     * Once an emote has been baked and registered, the emote id is the whole result — the parsed {@link Animation} is
+     * of no further use, so nothing but that id is kept. A repeat pick therefore costs no download at all, which is
+     * what keeps the library's download quota out of play.
+     *
+     * @param download invoked only on the first publication of this emote, ever
+     * @return the Hytale emote id to pass to {@code /emote}
+     */
+    public CompletableFuture<String> publish(UUID emoteId, Supplier<CompletableFuture<Animation>> download) {
+        String published = this.registered.get(emoteId);
+        if (published != null) {
+            return CompletableFuture.completedFuture(published);
+        }
+
+        EmoteCache.Entry cached = this.cache.get(emoteId);
+        if (cached != null) {
+            return CompletableFuture.completedFuture(publish(cached));
+        }
+
+        return this.publishing.computeIfAbsent(emoteId, id -> download.get()
+                .thenApply(this::store)
+                // Drop the in-flight entry either way: on success `registered` now answers, on failure a retry may work.
+                .whenComplete((result, throwable) -> this.publishing.remove(id))
+        );
+    }
+
+    /** @return what a client needs to play this emote, or null if the id is not one of ours */
+    public Published published(String id) {
+        return this.published.get(id);
+    }
+
+    /** @return the same, for a library emote that may not have been published at all yet */
+    public Published publishedFor(UUID emoteId) {
+        String id = this.registered.get(emoteId);
+        return id == null ? null : this.published.get(id);
+    }
+
+    /** Every published icon. The client's emote wheel lists all of them at once, so it needs all of them at once. */
+    public List<CommonAsset> icons() {
+        return this.published.values().stream().map(Published::icon).toList();
+    }
+
+    /**
+     * Republishes everything the cache holds. Called once the asset stores are up and before anyone is online, so the
+     * blobs go out with the rest of the required assets at login instead of being pushed at whoever happens to be
+     * connected.
+     *
+     * @return how many emotes were published
+     */
+    public int publishCached() {
+        int published = 0;
+        for (EmoteCache.Entry entry : this.cache.entries()) {
+            if (publish(entry) != null) {
+                published++;
+            }
+        }
+        return published;
+    }
+
+    /**
+     * Bakes an emote and publishes it from memory, without touching the cache.
+     * <p>
+     * This is the path for emotes that are already on disk in Emotecraft's own format — the built-in ones and anything
+     * dropped in the emote directory. Caching those would save a bake and risk serving a stale clip for an emote whose
+     * file changed under an unchanged UUID; only downloads are worth keeping.
+     *
+     * @return the Hytale emote id to pass to {@code /emote}, or null if the emote could not be converted
+     */
+    public String register(Animation emote) {
+        UUID uuid = emote.uuid();
+        String existing = this.registered.get(uuid);
+        if (existing != null) {
+            return existing;
+        }
+
+        String id = assetId(emote);
+        try {
+            BlockyAnimBaker.Baked animation = BlockyAnimBaker.bake(emote);
+            return publish(uuid, id, animation.frames(),
+                    new MemoryCommonAsset(ANIMATION_DIR + id + ".blockyanim", animation.json()),
+                    new MemoryCommonAsset(ICON_DIR + id + ".png", icon(emote))
+            );
+        } catch (Throwable th) {
+            CommonData.LOGGER.warn("Failed to publish emote {} to Hytale!", id, th);
+            return null;
+        }
+    }
+
+    /** Bakes a downloaded emote, writes it to the cache and publishes it from there. */
+    private String store(Animation emote) {
+        UUID uuid = emote.uuid();
+        String existing = this.registered.get(uuid);
+        if (existing != null) {
+            return existing;
+        }
+
+        String id = assetId(emote);
+        try {
+            BlockyAnimBaker.Baked animation = BlockyAnimBaker.bake(emote);
+            byte[] icon = icon(emote);
+
+            EmoteCache.Entry entry = this.cache.put(uuid, id, animation, icon);
+            if (entry != null) {
+                return publish(entry);
+            }
+
+            // The cache is unwritable, so this emote comes back next boot. It should still play this boot.
+            return publish(uuid, id, animation.frames(),
+                    new MemoryCommonAsset(ANIMATION_DIR + id + ".blockyanim", animation.json()),
+                    new MemoryCommonAsset(ICON_DIR + id + ".png", icon)
+            );
+        } catch (Throwable th) {
+            CommonData.LOGGER.warn("Failed to publish emote {} to Hytale!", id, th);
+            return null;
+        }
+    }
+
+    /**
+     * Publishes a cached emote. The blobs stay on disk until a client asks for one: {@code CommonAsset} holds them
+     * weakly and re-reads through {@link FileCommonAsset}, so a cache of hundreds costs an index in memory and nothing
+     * more.
+     */
+    private String publish(EmoteCache.Entry entry) {
+        String existing = this.registered.get(entry.emote());
+        if (existing != null) {
+            return existing;
+        }
+
+        try {
+            return publish(entry.emote(), entry.id(), entry.frames(),
+                    new FileCommonAsset(this.cache.animationFile(entry), ANIMATION_DIR + entry.id() + ".blockyanim", entry.hash(), null),
+                    new FileCommonAsset(this.cache.iconFile(entry), ICON_DIR + entry.id() + ".png", entry.iconHash(), null)
+            );
+        } catch (Throwable th) {
+            CommonData.LOGGER.warn("Failed to publish cached emote {} to Hytale!", entry.id(), th);
+            return null;
+        }
+    }
+
+    private String publish(UUID emoteId, String id, int frames, CommonAsset animation, CommonAsset icon) {
+        // Registering through the registry rather than through CommonAssetModule, which would also push both blobs at
+        // every connected player and announce each one with a toast. Delivery is EmoteDelivery's job.
+        CommonAssetRegistry.addCommonAsset(this.packKey, animation);
+        CommonAssetRegistry.addCommonAsset(this.packKey, icon);
+
+        // The EmoteAsset validators resolve both paths against that same registry, so the blobs have to land first.
+        EmoteAsset asset = new EmotecraftEmoteAsset(id, "emotecraft.emote." + id, animation.getName(), icon.getName(), false);
+        EmoteAsset.getAssetStore().loadAssets(this.packKey, List.of(asset));
+
+        this.published.put(id, new Published(id, animation, icon, frames));
+        this.registered.put(emoteId, id);
+        return id;
+    }
+
+    private static byte[] icon(Animation emote) {
+        ByteBuffer iconData = emote.data().getBinary("iconData");
+        if (iconData == null) {
+            return BLANK_ICON;
+        }
+
+        byte[] bytes = new byte[iconData.remaining()];
+        iconData.duplicate().get(bytes);
+        return bytes;
+    }
+
+    /**
+     * Derives a Hytale asset id from the emote's name. Ids may only contain {@code A-Za-z0-9_}, and the first letter of
+     * every underscore-separated segment must be uppercase, so the name is transliterated rather than used verbatim.
+     * The emote's UUID disambiguates, since two library emotes may well share a name.
+     */
+    private String assetId(Animation emote) {
+        StringBuilder id = new StringBuilder("Emotecraft_");
+        boolean startOfSegment = true;
+
+        for (char c : emote.getNameOrId().toCharArray()) {
+            if (c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z') {
+                id.append(startOfSegment ? Character.toUpperCase(c) : c);
+                startOfSegment = false;
+            } else if (c >= '0' && c <= '9' && !startOfSegment) {
+                id.append(c);
+            } else if (!startOfSegment) {
+                startOfSegment = true; // collapse any run of separators into the next segment boundary
+                id.append('_');
+            }
+        }
+
+        if (startOfSegment && !id.isEmpty() && id.charAt(id.length() - 1) == '_') {
+            id.setLength(id.length() - 1); // no trailing separator
+        }
+
+        return id + "_" + emote.uuid().toString().replace("-", "").substring(0, 8).toUpperCase(Locale.ROOT);
+    }
+}

--- a/hytale/src/main/java/io/github/kosmx/emotes/hytale/asset/EmoteCache.java
+++ b/hytale/src/main/java/io/github/kosmx/emotes/hytale/asset/EmoteCache.java
@@ -1,0 +1,173 @@
+package io.github.kosmx.emotes.hytale.asset;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.hypixel.hytale.server.core.asset.common.CommonAsset;
+import io.github.kosmx.emotes.common.CommonData;
+import io.github.kosmx.emotes.hytale.bake.BlockyAnimBaker;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
+/**
+ * Keeps every baked emote on disk, so the download that produced it is paid for once and not once per restart.
+ * <p>
+ * Nothing Hytale registers at runtime survives a shutdown, and re-fetching an emote body is the one operation the cloud
+ * library enforces a quota on. Baking is deterministic, so the pair of blobs a publication needs — the {@code
+ * .blockyanim} and the icon — is written out beside an index of {@code emote UUID -> asset id}, and a later run
+ * republishes straight from there without the library ever being asked.
+ * <p>
+ * The index carries {@link BlockyAnimBaker#VERSION}: the retargeting constants are still unverified, so the first
+ * calibration will invalidate every clip written before it. A mismatched stamp empties the whole directory rather than
+ * serving poses baked against different axes.
+ */
+public final class EmoteCache {
+    private static final String INDEX = "index.json";
+    private static final String ANIMATION_EXTENSION = ".blockyanim";
+    private static final String ICON_EXTENSION = ".png";
+
+    private final Path directory;
+    private final Map<UUID, Entry> entries = new ConcurrentHashMap<>();
+
+    /**
+     * @param id     the Hytale asset id the emote was published under, and the name of both files
+     * @param hash   hash of the animation blob, kept so the blob itself can stay on disk until a client asks for it
+     * @param frames the clip's length, which nothing else on this side of a restart can recover
+     */
+    public record Entry(UUID emote, String id, String hash, String iconHash, int frames) {
+    }
+
+    public EmoteCache(Path directory) {
+        this.directory = directory;
+
+        try {
+            load();
+        } catch (Throwable th) {
+            CommonData.LOGGER.warn("Failed to read the Hytale emote cache, starting empty!", th);
+            this.entries.clear();
+        }
+    }
+
+    public Entry get(UUID emote) {
+        return this.entries.get(emote);
+    }
+
+    public Collection<Entry> entries() {
+        return this.entries.values();
+    }
+
+    public Path animationFile(Entry entry) {
+        return this.directory.resolve(entry.id() + ANIMATION_EXTENSION);
+    }
+
+    public Path iconFile(Entry entry) {
+        return this.directory.resolve(entry.id() + ICON_EXTENSION);
+    }
+
+    /**
+     * Writes a freshly baked emote out.
+     *
+     * @return the stored entry, or null if it could not be written — in which case the caller is expected to publish
+     *         from memory anyway, since a broken cache should cost speed rather than the emote itself
+     */
+    public Entry put(UUID emote, String id, BlockyAnimBaker.Baked animation, byte[] icon) {
+        Entry entry = new Entry(emote, id, CommonAsset.hash(animation.json()), CommonAsset.hash(icon), animation.frames());
+
+        try {
+            Files.write(animationFile(entry), animation.json());
+            Files.write(iconFile(entry), icon);
+
+            this.entries.put(emote, entry);
+            save();
+
+            return entry;
+        } catch (IOException e) {
+            CommonData.LOGGER.warn("Failed to cache emote {}!", id, e);
+            return null;
+        }
+    }
+
+    private void load() throws IOException {
+        Files.createDirectories(this.directory);
+
+        Path index = this.directory.resolve(INDEX);
+        if (!Files.exists(index)) {
+            return;
+        }
+
+        JsonObject root;
+        try (Reader reader = Files.newBufferedReader(index, StandardCharsets.UTF_8)) {
+            root = JsonParser.parseReader(reader).getAsJsonObject();
+        } catch (Throwable th) {
+            // Without the index the blobs beside it cannot be addressed at all, so they go with it.
+            CommonData.LOGGER.warn("The Hytale emote cache index is unreadable, dropping the cache!", th);
+            clear();
+            return;
+        }
+
+        if (!root.has("bakeVersion") || root.get("bakeVersion").getAsInt() != BlockyAnimBaker.VERSION) {
+            CommonData.LOGGER.info("The Hytale emote cache was baked by another version, dropping it.");
+            clear();
+            return;
+        }
+
+        for (Map.Entry<String, JsonElement> emote : root.getAsJsonObject("emotes").entrySet()) {
+            JsonObject value = emote.getValue().getAsJsonObject();
+            Entry entry = new Entry(
+                    UUID.fromString(emote.getKey()), value.get("id").getAsString(),
+                    value.get("hash").getAsString(), value.get("iconHash").getAsString(),
+                    value.get("frames").getAsInt()
+            );
+
+            // An index entry without its blobs is worse than no entry at all: it would be published and then fail to
+            // resolve on the client, so a half-deleted directory simply costs a download.
+            if (Files.exists(animationFile(entry)) && Files.exists(iconFile(entry))) {
+                this.entries.put(entry.emote(), entry);
+            }
+        }
+    }
+
+    private void save() throws IOException {
+        JsonObject emotes = new JsonObject();
+        for (Entry entry : this.entries.values()) {
+            JsonObject value = new JsonObject();
+            value.addProperty("id", entry.id());
+            value.addProperty("hash", entry.hash());
+            value.addProperty("iconHash", entry.iconHash());
+            value.addProperty("frames", entry.frames());
+            emotes.add(entry.emote().toString(), value);
+        }
+
+        JsonObject root = new JsonObject();
+        root.addProperty("bakeVersion", BlockyAnimBaker.VERSION);
+        root.add("emotes", emotes);
+
+        // Through a temporary file: an index truncated by a crash mid-write would orphan every blob beside it.
+        Path temporary = this.directory.resolve(INDEX + ".tmp");
+        try (Writer writer = Files.newBufferedWriter(temporary, StandardCharsets.UTF_8)) {
+            writer.write(root.toString());
+        }
+        Files.move(temporary, this.directory.resolve(INDEX), StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    private void clear() throws IOException {
+        this.entries.clear();
+
+        try (Stream<Path> files = Files.list(this.directory)) {
+            for (Path file : files.toList()) {
+                Files.deleteIfExists(file);
+            }
+        }
+    }
+}

--- a/hytale/src/main/java/io/github/kosmx/emotes/hytale/asset/EmoteDelivery.java
+++ b/hytale/src/main/java/io/github/kosmx/emotes/hytale/asset/EmoteDelivery.java
@@ -1,0 +1,98 @@
+package io.github.kosmx.emotes.hytale.asset;
+
+import com.hypixel.hytale.common.util.ArrayUtil;
+import com.hypixel.hytale.component.ComponentAccessor;
+import com.hypixel.hytale.component.Ref;
+import com.hypixel.hytale.protocol.ToClientPacket;
+import com.hypixel.hytale.protocol.packets.setup.AssetFinalize;
+import com.hypixel.hytale.protocol.packets.setup.AssetInitialize;
+import com.hypixel.hytale.protocol.packets.setup.AssetPart;
+import com.hypixel.hytale.protocol.packets.setup.RequestCommonAssetsRebuild;
+import com.hypixel.hytale.server.core.asset.common.CommonAsset;
+import com.hypixel.hytale.server.core.asset.common.CommonAssetModule;
+import com.hypixel.hytale.server.core.io.PacketHandler;
+import com.hypixel.hytale.server.core.universe.PlayerRef;
+import com.hypixel.hytale.server.core.universe.world.PlayerUtil;
+import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Hands emote blobs to the clients that need them, and to no others.
+ * <p>
+ * The convenience registration call on {@code CommonAssetModule} pushes every asset to every connected player and
+ * announces each one with a toast, which for a library of hundreds is neither affordable nor quiet. Registration and
+ * delivery are separable — the registry call sends nothing — so this class does the sending, against the same audience
+ * the animation itself reaches: the entity tracker already knows which players can see whom.
+ * <p>
+ * Nothing is ever sent twice to the same connection. The bookkeeping is weakly keyed, so a disconnect forgets what that
+ * client held, which is correct — the next connection is a fresh client that may have kept nothing.
+ */
+public final class EmoteDelivery {
+    /** An asset and the bytes behind it, held so a blob cannot be collected between resolving it and writing it. */
+    public record Blob(CommonAsset asset, byte[] bytes) {
+    }
+
+    private final Map<PacketHandler, Set<String>> delivered = Collections.synchronizedMap(new WeakHashMap<>());
+
+    /**
+     * Reads whatever is still on disk. Cached blobs are held weakly and re-read through the file behind them, so this
+     * has to finish before anything touches a world thread.
+     */
+    public static CompletableFuture<List<Blob>> resolve(List<CommonAsset> assets) {
+        List<CompletableFuture<Blob>> blobs = assets.stream()
+                .map(asset -> asset.getBlob().thenApply(bytes -> new Blob(asset, bytes)))
+                .toList();
+
+        return CompletableFuture.allOf(blobs.toArray(CompletableFuture[]::new))
+                .thenApply(ignored -> blobs.stream().map(CompletableFuture::join).toList());
+    }
+
+    /**
+     * Sends to every player that can see the entity, including the entity itself. That is the same set
+     * {@code AnimationUtils} writes the animation packet to, so an emote and the clip it needs reach exactly the same
+     * clients.
+     */
+    public void send(Ref<EntityStore> ref, ComponentAccessor<EntityStore> accessor, List<Blob> blobs) {
+        PlayerUtil.forEachPlayerThatCanSeeEntity(ref, (viewerRef, viewer, componentAccessor) ->
+                send(viewer.getPacketHandler(), blobs), accessor);
+    }
+
+    /** Sends whatever one connection has not been sent already. */
+    public void send(PacketHandler handler, List<Blob> blobs) {
+        Set<String> held = this.delivered.computeIfAbsent(handler, connection -> ConcurrentHashMap.newKeySet());
+
+        List<ToClientPacket> packets = new ArrayList<>();
+        for (Blob blob : blobs) {
+            if (!held.add(blob.asset().getHash())) {
+                continue;
+            }
+
+            packets.add(new AssetInitialize(blob.asset().toPacket(), blob.bytes().length));
+            for (byte[] part : ArrayUtil.split(blob.bytes(), CommonAssetModule.MAX_FRAME)) {
+                packets.add(new AssetPart(part));
+            }
+            packets.add(new AssetFinalize());
+        }
+
+        if (packets.isEmpty()) {
+            return;
+        }
+
+        handler.write(packets.toArray(ToClientPacket[]::new));
+        handler.writeNoCache(new RequestCommonAssetsRebuild());
+    }
+
+    /** Sends to one player, resolving off-thread first. */
+    public void send(PlayerRef player, List<CommonAsset> assets) {
+        PacketHandler handler = player.getPacketHandler();
+        resolve(assets).thenAccept(blobs -> send(handler, blobs));
+    }
+}

--- a/hytale/src/main/java/io/github/kosmx/emotes/hytale/asset/EmotecraftEmoteAsset.java
+++ b/hytale/src/main/java/io/github/kosmx/emotes/hytale/asset/EmotecraftEmoteAsset.java
@@ -1,0 +1,25 @@
+package io.github.kosmx.emotes.hytale.asset;
+
+import com.hypixel.hytale.server.core.cosmetics.EmoteAsset;
+
+/**
+ * An {@link EmoteAsset} built in code rather than decoded from a pack's {@code Server/Emote/*.json}.
+ * <p>
+ * {@code EmoteAsset} exposes no setters — its fields are {@code protected} and normally filled in by its
+ * {@code AssetBuilderCodec} — so a subclass is the supported way to populate them from a different package.
+ * {@code AssetExtraInfo.Data} stays unset, which the store tolerates: it null-checks {@code codec.getData(asset)}
+ * before collecting contained assets.
+ */
+public final class EmotecraftEmoteAsset extends EmoteAsset {
+    public EmotecraftEmoteAsset(String id, String name, String animationPath, String iconPath, boolean looping) {
+        super(id);
+
+        this.name = name;
+        this.animationPath = animationPath;
+        this.iconPath = iconPath;
+        this.isLooping = looping;
+        // Keep the item visible: Emotecraft animates held items as first-class bones, and Hytale parents its
+        // R-/L-Attachment nodes to the hands, so an item follows the arms without any extra work.
+        this.hideItemInHand = false;
+    }
+}

--- a/hytale/src/main/java/io/github/kosmx/emotes/hytale/asset/MemoryCommonAsset.java
+++ b/hytale/src/main/java/io/github/kosmx/emotes/hytale/asset/MemoryCommonAsset.java
@@ -1,0 +1,27 @@
+package io.github.kosmx.emotes.hytale.asset;
+
+import com.hypixel.hytale.server.core.asset.common.CommonAsset;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.ref.WeakReference;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A {@link CommonAsset} backed purely by bytes we generated at runtime, with no file or classpath resource behind it.
+ * <p>
+ * {@link CommonAsset} keeps the blob in a {@link WeakReference}, so it may drop the cached future at any
+ * time and call {@link #getBlob0()} again — hence the hard reference kept here.
+ */
+public final class MemoryCommonAsset extends CommonAsset {
+    private final byte[] data;
+
+    public MemoryCommonAsset(@NotNull String name, @NotNull byte[] data) {
+        super(name, data); // hashes the bytes for us
+        this.data = data;
+    }
+
+    @Override
+    protected CompletableFuture<byte[]> getBlob0() {
+        return CompletableFuture.completedFuture(this.data);
+    }
+}

--- a/hytale/src/main/java/io/github/kosmx/emotes/hytale/bake/BlockyAnimBaker.java
+++ b/hytale/src/main/java/io/github/kosmx/emotes/hytale/bake/BlockyAnimBaker.java
@@ -1,0 +1,182 @@
+package io.github.kosmx.emotes.hytale.bake;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.zigythebird.playeranimcore.animation.Animation;
+import com.zigythebird.playeranimcore.animation.AnimationData;
+import com.zigythebird.playeranimcore.animation.HumanoidAnimationController;
+import com.zigythebird.playeranimcore.animation.RawAnimation;
+import com.zigythebird.playeranimcore.bones.PlayerAnimBone;
+import com.zigythebird.playeranimcore.enums.PlayState;
+import com.zigythebird.playeranimcore.molang.MolangLoader;
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Runs the Emotecraft animation engine over an emote and records the resulting pose into a Hytale {@code .blockyanim}.
+ * <p>
+ * Hytale's client can only play keyframe clips it already holds — there is no per-bone channel to stream a live pose
+ * over, and its animation format carries no expression language to parameterise (unlike Bedrock's Molang, which is what
+ * lets the Geyser extension drive bones through entity properties).
+ * <p>
+ * The pose is sampled rather than transcribed keyframe-for-keyframe on purpose: Emotecraft keeps a separate keyframe
+ * list per <i>axis</i>, each with its own easing and molang expressions, whereas a {@code .blockyanim} keyframe carries
+ * one whole vector and only knows {@code linear}/{@code smooth}. Merging those axis timelines means evaluating them at
+ * every distinct time anyway, so the engine is simply asked for the finished pose.
+ */
+public final class BlockyAnimBaker extends HumanoidAnimationController {
+    /**
+     * Identifies the shape of everything the cache holds — what this class and {@link HytaleRig} produce, and what the
+     * index records about it. <b>Bump it</b> whenever any of that changes: the retargeting constants are still
+     * uncalibrated, and a cached clip carries no hint of the axes it was baked with, so the stamp is the only thing
+     * that keeps a recalibration from silently replaying stale poses.
+     */
+    public static final int VERSION = 1;
+
+    /** Emotecraft animates on Minecraft's 20 ticks/second; Hytale plays clips at 60 fps. */
+    private static final int FRAMES_PER_TICK = 3;
+
+    private final JsonObject nodeAnimations = new JsonObject();
+
+    private BlockyAnimBaker() {
+        super((a, b, c) -> PlayState.STOP, MolangLoader::createNewEngine);
+    }
+
+    /**
+     * A finished clip. The frame count is how long it actually turned out to be, which is not always what the emote
+     * claims — the engine can stop early — and is the only thing that says when a performance is over.
+     */
+    public record Baked(byte[] json, int frames) {
+    }
+
+    /**
+     * @param emote an emote as loaded by {@code UniversalEmoteSerializer}
+     * @return a {@code .blockyanim} document ready for {@code CommonAssetRegistry}
+     */
+    public static Baked bake(Animation emote) {
+        BlockyAnimBaker baker = new BlockyAnimBaker();
+        baker.triggerAnimation(RawAnimation.begin().thenPlay(emote), 0.0F);
+
+        AnimationData data = new AnimationData(0.0F, 1.0F, false);
+        int frames = Math.max(1, Math.round(emote.length() * FRAMES_PER_TICK));
+        int baked = frames;
+
+        for (int frame = 0; frame < frames; frame++) {
+            int subTick = frame % FRAMES_PER_TICK;
+            if (subTick == 0) {
+                baker.tick(data);
+            }
+            if (!baker.isActive()) {
+                baked = frame;
+                break;
+            }
+
+            data.setPartialTick(subTick / (float) FRAMES_PER_TICK);
+            baker.setupAnim(data);
+            baker.sample(frame);
+        }
+
+        JsonObject root = new JsonObject();
+        root.addProperty("formatVersion", 1);
+        root.addProperty("duration", baked);
+        root.addProperty("holdLastKeyframe", false);
+        root.add("nodeAnimations", baker.nodeAnimations);
+        return new Baked(root.toString().getBytes(StandardCharsets.UTF_8), baked);
+    }
+
+    /** How long a clip of this many frames runs, in milliseconds. */
+    public static long duration(int frames) {
+        return frames * 1000L / (20 * FRAMES_PER_TICK);
+    }
+
+    /** Reads every bone the engine touched this frame onto the matching Hytale node. */
+    @SuppressWarnings("removal") // PlayerAnimBone#bend is the only way to read Emotecraft's limb flexing
+    private void sample(int frame) {
+        for (String boneName : this.activeBones.keySet()) {
+            String nodeName = HytaleRig.BONES.get(boneName);
+            if (nodeName == null) {
+                continue; // a bone with no Hytale counterpart, such as the elytra
+            }
+
+            // Local transforms, deliberately without parent composition: Hytale's skeleton really does nest
+            // Pelvis -> Thigh -> Calf and composes it client-side, unlike the flat Bedrock rig Geyser pre-composes for.
+            PlayerAnimBone bone = get3DTransform(boneName);
+            if (HytaleRig.CAPE_BONE.equals(boneName)) {
+                bone.rotation.x = -bone.rotation.x; // the Geyser controller corrects the same authoring quirk
+            }
+
+            Quaternionf orientation = HytaleRig.toHytaleOrientation(bone.rotation);
+            Vector3f position = HytaleRig.toHytalePosition(bone.position);
+            if (HytaleRig.ROOT_BONE.equals(boneName)) {
+                position.add(HytaleRig.pivotCompensation(orientation, HytaleRig.ROOT_PIVOT_OFFSET));
+            }
+
+            JsonObject node = node(nodeName);
+            key(node, "position", frame, vec3(position));
+            key(node, "orientation", frame, quat(orientation));
+            key(node, "shapeStretch", frame, vec3(bone.scale));
+
+            String bendTarget = HytaleRig.BEND_TARGETS.get(boneName);
+            if (bendTarget != null) {
+                key(node(bendTarget), "orientation", frame, quat(HytaleRig.bendToOrientation(bone.bend)));
+            }
+        }
+    }
+
+    /** Every animated node carries all five tracks, even the two an emote never fills. */
+    private JsonObject node(String name) {
+        JsonObject node = this.nodeAnimations.getAsJsonObject(name);
+        if (node == null) {
+            node = new JsonObject();
+            for (String track : new String[]{"position", "orientation", "shapeStretch", "shapeVisible", "shapeUvOffset"}) {
+                node.add(track, new JsonArray());
+            }
+            this.nodeAnimations.add(name, node);
+        }
+        return node;
+    }
+
+    /**
+     * Appends a keyframe, collapsing a stretch where the node does not move down to the two keyframes that bound it.
+     * <p>
+     * The trailing one is not just a size saving: keyframes interpolate linearly, so a bone that holds still from frame
+     * 0 to 99 and moves on 100 would drift across the whole span instead of staying put. Once two keyframes in a row
+     * carry the same delta, the second is simply dragged forward to the current frame.
+     */
+    private static void key(JsonObject node, String track, int frame, JsonObject delta) {
+        JsonArray keyframes = node.getAsJsonArray(track);
+        int size = keyframes.size();
+
+        if (size > 0 && delta.equals(keyframes.get(size - 1).getAsJsonObject().get("delta"))) {
+            if (size > 1 && delta.equals(keyframes.get(size - 2).getAsJsonObject().get("delta"))) {
+                keyframes.get(size - 1).getAsJsonObject().addProperty("time", frame); // extend the still run
+                return;
+            }
+        }
+
+        JsonObject keyframe = new JsonObject();
+        keyframe.addProperty("time", frame);
+        keyframe.add("delta", delta);
+        keyframe.addProperty("interpolationType", "linear"); // the engine already applied the emote's own easing
+        keyframes.add(keyframe);
+    }
+
+    private static JsonObject vec3(Vector3f value) {
+        JsonObject delta = new JsonObject();
+        delta.addProperty("x", value.x);
+        delta.addProperty("y", value.y);
+        delta.addProperty("z", value.z);
+        return delta;
+    }
+
+    private static JsonObject quat(Quaternionf value) {
+        JsonObject delta = new JsonObject();
+        delta.addProperty("x", value.x);
+        delta.addProperty("y", value.y);
+        delta.addProperty("z", value.z);
+        delta.addProperty("w", value.w);
+        return delta;
+    }
+}

--- a/hytale/src/main/java/io/github/kosmx/emotes/hytale/bake/HytaleRig.java
+++ b/hytale/src/main/java/io/github/kosmx/emotes/hytale/bake/HytaleRig.java
@@ -1,0 +1,126 @@
+package io.github.kosmx.emotes.hytale.bake;
+
+import org.joml.Quaternionf;
+import org.joml.Vector3f;
+
+import java.util.Map;
+
+/**
+ * Translates the Minecraft humanoid rig that Emotecraft animates onto Hytale's player skeleton
+ * ({@code Common/Characters/Player.blockymodel}).
+ * <p>
+ * Both formats express a pose as a <i>delta from the rest pose</i>, so no rest transform has to be folded in here —
+ * only the bone naming, the unit scale and the axis convention differ.
+ */
+public final class HytaleRig {
+    private HytaleRig() {
+    }
+
+    /**
+     * Translations are retargeted proportionally rather than by raw unit conversion.
+     * <p>
+     * Emotecraft animates in its own frame of 1/16-block units with the neck at y=24 (1.5 blocks); Hytale's rig uses
+     * 1/32-block units with the head node at y=68 (2.125 blocks), so its character is markedly taller. Converting units
+     * alone (a flat x2) would keep absolute distances but shrink every gesture relative to the body — a hand raised to
+     * the head would stop short of it. Scaling by the two rigs' proportions keeps the pose's intent instead.
+     */
+    public static final float POSITION_SCALE = 68.0F / 24.0F;
+
+    /**
+     * Emotecraft bone -> Hytale node. Hytale splits the Minecraft torso into {@code Pelvis}/{@code Belly}/{@code Chest}
+     * and each limb into three segments, so the Minecraft bone drives the topmost segment and its bend value drives the
+     * joint below it (see {@link #BEND_TARGETS}).
+     * <p>
+     * Note that Hytale's {@code L-} nodes sit on +X and {@code R-} on -X, matching Minecraft's left/right.
+     */
+    public static final Map<String, String> BONES = Map.ofEntries(
+            Map.entry("head", "Head"),
+            // Emotecraft's "body" displaces the whole player, which in Hytale hangs off the pelvis
+            Map.entry("body", "Pelvis"),
+            Map.entry("torso", "Chest"),
+            Map.entry("left_arm", "L-Arm"),
+            Map.entry("right_arm", "R-Arm"),
+            Map.entry("left_leg", "L-Thigh"),
+            Map.entry("right_leg", "R-Thigh"),
+            // Held items. Hytale parents these attachment nodes to the hands, so an item tracks the arm on its own;
+            // mapping them as well lets an emote that poses the item relative to the hand keep doing so.
+            Map.entry("left_item", "L-Attachment"),
+            Map.entry("right_item", "R-Attachment"),
+            // The cape rides Hytale's back slot, which hangs off the chest. Emotecraft's "elytra" bone is deliberately
+            // left out: Hytale has no elytra and only this one node on the back, so mapping both would have the two
+            // bones overwrite each other frame by frame.
+            Map.entry("cape", "Back-Attachment")
+    );
+
+    /** Emotecraft authors the cape's pitch inverted relative to the rest of the rig. */
+    public static final String CAPE_BONE = "cape";
+
+    /**
+     * Emotecraft encodes elbow/knee/waist flexing as a single {@code bend} scalar on the parent bone. Hytale has real
+     * joints instead, so the bend is replayed as a pitch rotation on the segment below.
+     */
+    public static final Map<String, String> BEND_TARGETS = Map.of(
+            "left_arm", "L-Forearm",
+            "right_arm", "R-Forearm",
+            "left_leg", "L-Calf",
+            "right_leg", "R-Calf",
+            "torso", "Belly"
+    );
+
+    /**
+     * Both rigs are Y-up, so the difference is a half turn about Y: {@code (x, y, z) -> (-x, y, -z)}.
+     * <p>
+     * Emotecraft does not animate in Minecraft's Y-down {@code ModelPart} space — the engine's own bone table places
+     * the origin at the feet with the head at y=+24, the right arm at x=+5 and the cape at z=+2, i.e. +X is the
+     * character's right and +Z is behind them. Hytale mirrors both: its {@code R-} nodes sit on -X ({@code R-Shoulder}
+     * at x=-14.5) and the back is at -Z ({@code Back-Attachment} at z=-18).
+     */
+    public static Vector3f toHytalePosition(Vector3f mcPosition) {
+        return new Vector3f(
+                -mcPosition.x * POSITION_SCALE,
+                mcPosition.y * POSITION_SCALE,
+                -mcPosition.z * POSITION_SCALE
+        );
+    }
+
+    /**
+     * Converts an Emotecraft euler rotation (radians) into the quaternion delta Hytale expects.
+     * <p>
+     * The triple is applied Z-Y-X, the order Minecraft composes part rotations in, and the same half turn about Y as
+     * {@link #toHytalePosition} negates the two axes perpendicular to it.
+     */
+    public static Quaternionf toHytaleOrientation(Vector3f mcRotation) {
+        return new Quaternionf().rotateZYX(-mcRotation.z, mcRotation.y, -mcRotation.x);
+    }
+
+    /** A bend flexes the joint about its own X axis, which the half turn about Y reverses. */
+    public static Quaternionf bendToOrientation(float bend) {
+        return new Quaternionf().rotateX(-bend);
+    }
+
+    /** The Emotecraft bone whose rotation moves the whole character rather than a limb. */
+    public static final String ROOT_BONE = "body";
+
+    /**
+     * How far Emotecraft's root pivot sits from the node it drives, in the node's parent frame.
+     * <p>
+     * Emotecraft turns the whole character about the waist ({@code body} at y=12, i.e. y=34 once scaled), while
+     * Hytale's {@code Pelvis} sits at y=51 — half a block apart, enough to visibly change a full-body lean.
+     * <p>
+     * Only the root gets this treatment. Every other joint has to keep turning about the target rig's own joint: the
+     * Emotecraft pivots for {@code torso} and the limbs land 0.2-0.3 blocks away from the matching Hytale sockets
+     * (Emotecraft's {@code torso} pivots at the neck, not the chest), so honouring them would swing each part out of
+     * its socket and tear the skeleton apart. Differing proportions are retargeted, not reproduced.
+     */
+    public static final Vector3f ROOT_PIVOT_OFFSET = new Vector3f(0.0F, 34.0F - 51.0F, 0.0F);
+
+    /**
+     * The translation that turns a rotation about the node's own origin into one about a pivot {@code offset} away.
+     * <p>
+     * Rotating about a point C gives {@code X' = R*X + (C - R*C)}, while a node rotates about its own origin P and then
+     * takes a translation T: {@code X' = R*X + (P - R*P) + T}. Equating the two leaves {@code T = (I - R)(C - P)}.
+     */
+    public static Vector3f pivotCompensation(Quaternionf rotation, Vector3f offset) {
+        return new Vector3f(offset).sub(rotation.transform(new Vector3f(offset)));
+    }
+}

--- a/hytale/src/main/java/io/github/kosmx/emotes/hytale/commands/EmotecraftCommand.java
+++ b/hytale/src/main/java/io/github/kosmx/emotes/hytale/commands/EmotecraftCommand.java
@@ -1,0 +1,44 @@
+package io.github.kosmx.emotes.hytale.commands;
+
+import com.hypixel.hytale.component.Ref;
+import com.hypixel.hytale.component.Store;
+import com.hypixel.hytale.server.core.command.system.CommandContext;
+import com.hypixel.hytale.server.core.command.system.basecommands.AbstractPlayerCommand;
+import com.hypixel.hytale.server.core.entity.entities.Player;
+import com.hypixel.hytale.server.core.universe.PlayerRef;
+import com.hypixel.hytale.server.core.universe.world.World;
+import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
+import io.github.kosmx.emotes.hytale.EmotePlayback;
+import io.github.kosmx.emotes.hytale.HytaleEmoteRegistry;
+import io.github.kosmx.emotes.hytale.asset.EmoteDelivery;
+import io.github.kosmx.emotes.hytale.library.EmoteLibrary;
+import io.github.kosmx.emotes.hytale.ui.EmoteListPage;
+import org.jetbrains.annotations.NotNull;
+
+/** Opens the emote library browser. */
+public final class EmotecraftCommand extends AbstractPlayerCommand {
+    private final EmoteLibrary library;
+    private final HytaleEmoteRegistry registry;
+    private final EmoteDelivery delivery;
+    private final EmotePlayback playback;
+
+    public EmotecraftCommand(EmoteLibrary library, HytaleEmoteRegistry registry,
+                             EmoteDelivery delivery, EmotePlayback playback) {
+        super("emotecraft", "emotecraft.commands.emotecraft.desc");
+        this.library = library;
+        this.registry = registry;
+        this.delivery = delivery;
+        this.playback = playback;
+        this.requirePermission("emotecraft.command.emotecraft");
+        this.addAliases("emotes");
+    }
+
+    @Override
+    protected void execute(@NotNull CommandContext context, @NotNull Store<EntityStore> store,
+                           @NotNull Ref<EntityStore> ref, @NotNull PlayerRef playerRef, @NotNull World world) {
+        // Already on the player's world thread, which is where PageManager expects to be driven from.
+        Player player = store.getComponent(ref, Player.getComponentType());
+        player.getPageManager().openCustomPage(ref, store,
+                new EmoteListPage(playerRef, this.library, this.registry, this.delivery, this.playback));
+    }
+}

--- a/hytale/src/main/java/io/github/kosmx/emotes/hytale/entity/EmoteTrackerSystem.java
+++ b/hytale/src/main/java/io/github/kosmx/emotes/hytale/entity/EmoteTrackerSystem.java
@@ -1,0 +1,90 @@
+package io.github.kosmx.emotes.hytale.entity;
+
+import com.hypixel.hytale.component.ArchetypeChunk;
+import com.hypixel.hytale.component.CommandBuffer;
+import com.hypixel.hytale.component.ComponentType;
+import com.hypixel.hytale.component.Ref;
+import com.hypixel.hytale.component.Store;
+import com.hypixel.hytale.component.SystemGroup;
+import com.hypixel.hytale.component.query.Query;
+import com.hypixel.hytale.component.system.tick.EntityTickingSystem;
+import com.hypixel.hytale.protocol.AnimationSlot;
+import com.hypixel.hytale.server.core.modules.entity.component.ActiveAnimationComponent;
+import com.hypixel.hytale.server.core.modules.entity.tracker.EntityTrackerSystems;
+import com.hypixel.hytale.server.core.universe.PlayerRef;
+import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
+import io.github.kosmx.emotes.hytale.asset.EmoteDelivery;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Keeps an emote in sync with who can see it.
+ * <p>
+ * The core replays an entity's active animation to anyone who comes into range, but only the animation id — the clip
+ * behind it has to be there first, and nothing in the core knows that. So this runs in the same group, against the same
+ * newly-visible set, and hands the clip to each arrival. Writing straight to their connection puts it ahead of the
+ * core's own update, which is only queued here and flushed a group later.
+ * <p>
+ * It is also what ends an emote: without the clip's own length nothing would ever clear the active animation, and every
+ * newcomer would be shown a performance that finished long ago.
+ */
+public final class EmoteTrackerSystem extends EntityTickingSystem<EntityStore> {
+    private final ComponentType<EntityStore, EntityTrackerSystems.Visible> visibleType = EntityTrackerSystems.Visible.getComponentType();
+    private final ComponentType<EntityStore, PlayerRef> playerType = PlayerRef.getComponentType();
+    private final ComponentType<EntityStore, Emoting> emotingType = Emoting.getComponentType();
+
+    /**
+     * Deliberately not narrowed to entities that are visible to somebody: an emote nobody watched still has to end.
+     * The visible component is absent whenever a performer is alone, and querying for it would leave that emote hanging
+     * until the next person walked past — who would then be shown it.
+     */
+    private final Query<EntityStore> query = this.emotingType;
+
+    private final EmoteDelivery delivery;
+
+    public EmoteTrackerSystem(EmoteDelivery delivery) {
+        this.delivery = delivery;
+    }
+
+    @NotNull
+    @Override
+    public SystemGroup<EntityStore> getGroup() {
+        return EntityTrackerSystems.QUEUE_UPDATE_GROUP;
+    }
+
+    @NotNull
+    @Override
+    public Query<EntityStore> getQuery() {
+        return this.query;
+    }
+
+    @Override
+    public void tick(float dt, int index, @NotNull ArchetypeChunk<EntityStore> archetypeChunk,
+                     @NotNull Store<EntityStore> store, @NotNull CommandBuffer<EntityStore> commandBuffer) {
+        Emoting emoting = archetypeChunk.getComponent(index, this.emotingType);
+        if (emoting == null || emoting.getId() == null) {
+            return;
+        }
+
+        if (emoting.hasEnded(System.currentTimeMillis())) {
+            emoting.stop();
+
+            ActiveAnimationComponent active = archetypeChunk.getComponent(index, ActiveAnimationComponent.getComponentType());
+            if (active != null) {
+                active.setPlayingAnimation(AnimationSlot.Emote, null);
+            }
+            return;
+        }
+
+        EntityTrackerSystems.Visible visible = archetypeChunk.getComponent(index, this.visibleType);
+        if (visible == null || visible.newlyVisibleTo.isEmpty()) {
+            return;
+        }
+
+        for (Ref<EntityStore> viewerRef : visible.newlyVisibleTo.keySet()) {
+            PlayerRef viewer = store.getComponent(viewerRef, this.playerType);
+            if (viewer != null) {
+                this.delivery.send(viewer.getPacketHandler(), emoting.getBlobs());
+            }
+        }
+    }
+}

--- a/hytale/src/main/java/io/github/kosmx/emotes/hytale/entity/Emoting.java
+++ b/hytale/src/main/java/io/github/kosmx/emotes/hytale/entity/Emoting.java
@@ -1,0 +1,67 @@
+package io.github.kosmx.emotes.hytale.entity;
+
+import com.hypixel.hytale.component.Component;
+import com.hypixel.hytale.component.ComponentType;
+import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
+import io.github.kosmx.emotes.hytale.asset.EmoteDelivery;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * The emote an entity is performing right now, and the blobs a late arrival will need to see it.
+ * <p>
+ * Emotecraft's other backends keep the same thing per player: what is playing and since when, so that anyone who starts
+ * tracking the performer mid-emote can be told about it. The blobs ride along because delivering them cannot wait on a
+ * disk read once a viewer has already appeared — they are resolved when the emote starts and held for as long as it
+ * lasts, which is also the only window in which anyone can need them.
+ */
+public final class Emoting implements Component<EntityStore> {
+    private static ComponentType<EntityStore, Emoting> type;
+
+    private String id;
+    private List<EmoteDelivery.Blob> blobs = List.of();
+    private long endsAt;
+
+    public static ComponentType<EntityStore, Emoting> getComponentType() {
+        return type;
+    }
+
+    /** Called once from the plugin, since a component type only exists after the store registry has been told about it. */
+    public static void setComponentType(ComponentType<EntityStore, Emoting> componentType) {
+        type = componentType;
+    }
+
+    public void start(String id, List<EmoteDelivery.Blob> blobs, long endsAt) {
+        this.id = id;
+        this.blobs = blobs;
+        this.endsAt = endsAt;
+    }
+
+    /** Lets go of the blobs as well; holding a clip for an emote that has ended keeps it out of the weak cache. */
+    public void stop() {
+        this.id = null;
+        this.blobs = List.of();
+    }
+
+    public String getId() {
+        return this.id;
+    }
+
+    public List<EmoteDelivery.Blob> getBlobs() {
+        return this.blobs;
+    }
+
+    public boolean hasEnded(long now) {
+        return now >= this.endsAt;
+    }
+
+    @NotNull
+    @Override
+    @SuppressWarnings("MethodDoesntCallSuperMethod") // matches how the core's own components clone
+    public Component<EntityStore> clone() {
+        Emoting copy = new Emoting();
+        copy.start(this.id, this.blobs, this.endsAt);
+        return copy;
+    }
+}

--- a/hytale/src/main/java/io/github/kosmx/emotes/hytale/library/EmoteLibrary.java
+++ b/hytale/src/main/java/io/github/kosmx/emotes/hytale/library/EmoteLibrary.java
@@ -1,0 +1,115 @@
+package io.github.kosmx.emotes.hytale.library;
+
+import com.hypixel.hytale.protocol.packets.connection.Connect;
+import com.hypixel.hytale.server.core.io.PacketHandler;
+import com.hypixel.hytale.server.core.io.adapter.PacketAdapters;
+import com.hypixel.hytale.server.core.io.adapter.PacketFilter;
+import com.hypixel.hytale.server.core.io.adapter.PacketWatcher;
+import com.hypixel.hytale.server.core.universe.PlayerRef;
+import com.zigythebird.playeranimcore.animation.Animation;
+import io.github.kosmx.emotes.common.CommonData;
+import io.github.kosmx.emotes.common.network.EmotePacket;
+import io.github.kosmx.emotes.server.serializer.UniversalEmoteSerializer;
+import org.redlance.emotecraftlibrary.sdk.EmoteLibraryClient;
+import org.redlance.emotecraftlibrary.sdk.GameEmoteInfo;
+
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.function.Function;
+
+/**
+ * Bridges the cloud emote library to Hytale players.
+ * <p>
+ * The SDK authorizes one <i>player</i> per client — {@code listLiked}/{@code search} return that account's own likes —
+ * so every player gets their own {@link EmoteLibraryClient}. Authorization needs the player's session-service identity
+ * token, which the server keeps private to the login-phase handshake handler; it is instead read straight off the
+ * {@code Connect} packet, the only place a mod can see it.
+ */
+public final class EmoteLibrary implements AutoCloseable {
+    private static final String BASE_URL = "https://emotes.redlance.org/";
+
+    /** Every SDK call except the live stream blocks, and none of them may run on a world thread. */
+    private static final Executor EXECUTOR = Executors.newCachedThreadPool(Thread.ofVirtual()
+            .name("emotecraft-library-", 0)
+            .factory()
+    );
+
+    /**
+     * Identity tokens by connection. Weakly keyed so an entry dies with the connection that owns it — there is no
+     * disconnect hook to clean up after, and holding a player's credential longer than their session would be careless.
+     */
+    private final Map<PacketHandler, String> tokens = Collections.synchronizedMap(new WeakHashMap<>());
+    private final Map<UUID, EmoteLibraryClient> clients = new ConcurrentHashMap<>();
+
+    private final String userAgent;
+    private final PacketFilter watcher;
+
+    public EmoteLibrary(String modVersion, String serverVersion) {
+        this.userAgent = String.format("%s/%s (hytale; %s)", CommonData.MOD_NAME, modVersion, serverVersion);
+        this.watcher = PacketAdapters.registerInbound((PacketWatcher) (handler, packet) -> {
+            if (packet instanceof Connect connect && connect.identityToken != null) {
+                this.tokens.put(handler, connect.identityToken);
+            }
+        });
+    }
+
+    /**
+     * Runs a library call for one player on a background thread, authorizing that player's session on first use.
+     *
+     * @return the call's result, or a failed future if the player never presented an identity token
+     */
+    public <R> CompletableFuture<R> execute(PlayerRef player, Function<EmoteLibraryClient, R> request) {
+        return CompletableFuture.supplyAsync(() -> request.apply(client(player)), EXECUTOR);
+    }
+
+    private EmoteLibraryClient client(PlayerRef player) {
+        EmoteLibraryClient client = this.clients.computeIfAbsent(player.getUuid(),
+                uuid -> new EmoteLibraryClient(BASE_URL, this.userAgent));
+
+        // Sessions expire on an idle window, so re-authorizing is the normal path rather than an error case.
+        if (!client.isAuthorized()) {
+            String token = this.tokens.get(player.getPacketHandler());
+            if (token == null) {
+                throw new IllegalStateException("No identity token for " + player.getUsername());
+            }
+            client.authorizeHytale(token);
+        }
+        return client;
+    }
+
+    /**
+     * Downloads a liked emote's body and parses it with the same reader the Minecraft client uses.
+     * <p>
+     * This is the call the library enforces a download quota on, so callers are expected to go through
+     * {@code HytaleEmoteRegistry#publish}, which skips it entirely for an emote that is already published.
+     */
+    public CompletableFuture<Animation> download(PlayerRef player, UUID emoteId) {
+        return execute(player, client -> client.getBinary(emoteId, EmotePacket.defaultVersions))
+                .thenApply(EmoteLibrary::parse);
+    }
+
+    /** A page of the player's own liked emotes. */
+    public CompletableFuture<List<GameEmoteInfo>> listLiked(PlayerRef player, int offset, int limit) {
+        return execute(player, client -> client.listLiked(offset, limit).getData());
+    }
+
+    private static Animation parse(InputStream body) {
+        return UniversalEmoteSerializer.readData(body, "emote.emotecraft").values().iterator().next();
+    }
+
+    @Override
+    public void close() {
+        PacketAdapters.deregisterInbound(this.watcher);
+        this.clients.values().forEach(EmoteLibraryClient::close);
+        this.clients.clear();
+        this.tokens.clear();
+    }
+}

--- a/hytale/src/main/java/io/github/kosmx/emotes/hytale/services/HytaleInstanceService.java
+++ b/hytale/src/main/java/io/github/kosmx/emotes/hytale/services/HytaleInstanceService.java
@@ -1,0 +1,44 @@
+package io.github.kosmx.emotes.hytale.services;
+
+import io.github.kosmx.emotes.server.services.InstanceService;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Roots Emotecraft's directories at the plugin's own data directory rather than the server's working directory.
+ * <p>
+ * The fallback implementation resolves everything against {@code Paths.get("")}, which on a Hytale server would scatter
+ * the config and the emote cache across the server root. Hytale hands every plugin a directory of its own, so
+ * {@link #setDataDirectory} points this service at it as soon as the plugin starts.
+ */
+public final class HytaleInstanceService implements InstanceService {
+    private static volatile Path dataDirectory;
+
+    /** Called from the plugin's constructor, before anything reads a path. */
+    public static void setDataDirectory(Path directory) {
+        dataDirectory = directory;
+    }
+
+    @Override
+    public Path getGameDirectory() {
+        Path directory = dataDirectory;
+        return directory != null ? directory : Paths.get("");
+    }
+
+    @Override
+    public Path getCacheDirectory() {
+        // The default nests a directory named after the mod inside the game directory, which here already is one.
+        return getGameDirectory().resolve("cache");
+    }
+
+    @Override
+    public int getPriority() {
+        return 0; // above InstanceServiceImpl's LOWEST_PRIORITY, so this one wins
+    }
+
+    @Override
+    public boolean isServiceActive() {
+        return true;
+    }
+}

--- a/hytale/src/main/java/io/github/kosmx/emotes/hytale/ui/EmoteListPage.java
+++ b/hytale/src/main/java/io/github/kosmx/emotes/hytale/ui/EmoteListPage.java
@@ -1,0 +1,221 @@
+package io.github.kosmx.emotes.hytale.ui;
+
+import com.hypixel.hytale.codec.Codec;
+import com.hypixel.hytale.codec.KeyedCodec;
+import com.hypixel.hytale.codec.builder.BuilderCodec;
+import com.hypixel.hytale.component.Ref;
+import com.hypixel.hytale.component.Store;
+import com.hypixel.hytale.protocol.packets.interface_.CustomPageLifetime;
+import com.hypixel.hytale.protocol.packets.interface_.CustomUIEventBindingType;
+import com.hypixel.hytale.server.core.asset.common.CommonAsset;
+import com.hypixel.hytale.server.core.entity.entities.player.pages.InteractiveCustomUIPage;
+import com.hypixel.hytale.server.core.ui.builder.EventData;
+import com.hypixel.hytale.server.core.ui.builder.UICommandBuilder;
+import com.hypixel.hytale.server.core.ui.builder.UIEventBuilder;
+import com.hypixel.hytale.server.core.universe.PlayerRef;
+import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
+import io.github.kosmx.emotes.hytale.EmotePlayback;
+import io.github.kosmx.emotes.hytale.HytaleEmoteRegistry;
+import io.github.kosmx.emotes.hytale.asset.EmoteDelivery;
+import io.github.kosmx.emotes.hytale.library.EmoteLibrary;
+import org.jetbrains.annotations.NotNull;
+import org.redlance.emotecraftlibrary.sdk.GameEmoteInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Browses the player's cloud emote library: a page of ten, a search box, and prev/next below.
+ * <p>
+ * Nothing is downloaded to browse — a page costs one metadata call, and an emote's body is only fetched the first time
+ * somebody actually picks it (see {@code HytaleEmoteRegistry#publish}). That matters because the library enforces a
+ * download quota, and pushing every liked emote at login would burn it for nothing.
+ */
+public final class EmoteListPage extends InteractiveCustomUIPage<EmoteListPage.Data> {
+    private static final int PER_PAGE = 10;
+
+    private static final String ROOT = "Pages/Emotecraft/EmoteList.ui";
+    private static final String ROW = "Pages/Emotecraft/EmoteRow.ui";
+
+    private final EmoteLibrary library;
+    private final HytaleEmoteRegistry registry;
+    private final EmoteDelivery delivery;
+    private final EmotePlayback playback;
+
+    private List<GameEmoteInfo> entries = List.of();
+    private String query = "";
+    private int page;
+    private boolean loading;
+    private String status = "";
+
+    public EmoteListPage(@NotNull PlayerRef playerRef, EmoteLibrary library, HytaleEmoteRegistry registry,
+                         EmoteDelivery delivery, EmotePlayback playback) {
+        super(playerRef, CustomPageLifetime.CanDismiss, Data.CODEC);
+        this.library = library;
+        this.registry = registry;
+        this.delivery = delivery;
+        this.playback = playback;
+    }
+
+    @Override
+    public void build(@NotNull Ref<EntityStore> ref, @NotNull UICommandBuilder cmd,
+                      @NotNull UIEventBuilder ev, @NotNull Store<EntityStore> store) {
+        cmd.append(ROOT);
+
+        // The query is read off the field at the moment the button fires, so nothing has to be tracked per keystroke -
+        // which also sidesteps PageManager dropping Data events while an update is still unacknowledged.
+        EventData search = EventData.of(Data.KEY_ACTION, Action.SEARCH.name()).append(Data.KEY_QUERY, "#SearchInput.Value");
+        ev.addEventBinding(CustomUIEventBindingType.Activating, "#Search", search);
+        ev.addEventBinding(CustomUIEventBindingType.Validating, "#SearchInput", search); // Enter in the field
+        ev.addEventBinding(CustomUIEventBindingType.Activating, "#Prev", EventData.of(Data.KEY_ACTION, Action.PREV.name()));
+        ev.addEventBinding(CustomUIEventBindingType.Activating, "#Next", EventData.of(Data.KEY_ACTION, Action.NEXT.name()));
+
+        render(cmd, ev);
+        if (this.entries.isEmpty() && !this.loading) {
+            fetch();
+        }
+    }
+
+    @Override
+    public void handleDataEvent(@NotNull Ref<EntityStore> ref, @NotNull Store<EntityStore> store, @NotNull Data data) {
+        if (data.emote != null) {
+            play(UUID.fromString(data.emote));
+            return;
+        }
+
+        if (data.action == null) {
+            return;
+        }
+
+        switch (Action.valueOf(data.action)) {
+            case SEARCH -> {
+                this.query = data.query == null ? "" : data.query.trim();
+                this.page = 0;
+                fetch();
+            }
+            case PREV -> {
+                if (this.page > 0) {
+                    this.page--;
+                    fetch();
+                }
+            }
+            case NEXT -> {
+                this.page++;
+                fetch();
+            }
+        }
+
+        refresh();
+    }
+
+    /** Pulls one page of metadata off the library. Blocking SDK work never touches the world thread. */
+    private void fetch() {
+        this.loading = true;
+        this.status = "...";
+
+        int offset = this.page * PER_PAGE;
+        var request = this.query.isEmpty()
+                ? this.library.listLiked(this.playerRef, offset, PER_PAGE)
+                : this.library.execute(this.playerRef, client -> client.search(this.query, offset, PER_PAGE).getData());
+
+        request.whenComplete((result, throwable) -> {
+            this.loading = false;
+            if (throwable != null) {
+                this.status = throwable.getMessage();
+            } else {
+                this.entries = result;
+                this.status = "";
+            }
+            refresh(); // InteractiveCustomUIPage#sendUpdate hops to the world thread itself
+        });
+    }
+
+    private void refresh() {
+        UICommandBuilder cmd = new UICommandBuilder();
+        UIEventBuilder ev = new UIEventBuilder();
+        render(cmd, ev);
+        sendUpdate(cmd, ev, false); // patch in place - a full rebuild would drop the search box's contents
+    }
+
+    private void render(UICommandBuilder cmd, UIEventBuilder ev) {
+        cmd.clear("#List");
+
+        List<CommonAsset> icons = new ArrayList<>();
+        for (int i = 0; i < this.entries.size(); i++) {
+            GameEmoteInfo info = this.entries.get(i);
+            String row = "#List[" + i + "]";
+
+            cmd.append("#List", ROW);
+            // These three arrive as Minecraft component JSON, not plain text - see McComponents.
+            String language = this.playerRef.getLanguage();
+            cmd.set(row + " #Name.Text", McComponents.toMessage(info.getName(), language));
+            cmd.set(row + " #Author.Text", McComponents.toMessage(info.getAuthor(), language));
+            cmd.set(row + " #Description.Text", McComponents.toMessage(info.getDescription(), language));
+
+            cmd.set(row + " #Tags.Text", String.join(" · ", info.getTags()));
+
+            // Only a published emote has an icon registered as a common asset; until then the row shows its fallback.
+            HytaleEmoteRegistry.Published published = this.registry.publishedFor(info.getId());
+            if (published != null) {
+                cmd.set(row + " #Icon.AssetPath", published.icon().getName());
+                icons.add(published.icon());
+            }
+
+            ev.addEventBinding(CustomUIEventBindingType.Activating, row,
+                    EventData.of(Data.KEY_EMOTE, info.getId().toString()));
+        }
+
+        // Whoever is reading this page is the one client that needs these icons right now.
+        this.delivery.send(this.playerRef, icons);
+
+        cmd.set("#Status.Text", this.status);
+        cmd.set("#Prev.Disabled", this.page == 0 || this.loading);
+        // The library reports no total, so "next" stays open until a short page proves this was the last one.
+        cmd.set("#Next.Disabled", this.entries.size() < PER_PAGE || this.loading);
+    }
+
+    /**
+     * Publishes the emote if this is its first use, then plays it.
+     * <p>
+     * Publishing also puts the emote in the client's own emote menu, since that menu is built from the built-in list
+     * plus everything in the {@code EmoteAsset} store — so picking an emote here is enough to make it reachable from
+     * the wheel afterwards, without any per-player call (there is none).
+     */
+    private void play(UUID emoteId) {
+        this.registry.publish(emoteId, () -> this.library.download(this.playerRef, emoteId))
+                .whenComplete((id, throwable) -> {
+                    if (throwable != null || id == null) {
+                        this.status = throwable == null ? "" : throwable.getMessage();
+                        refresh();
+                        return;
+                    }
+
+                    this.playback.play(this.playerRef, id);
+
+                    this.status = "";
+                    refresh(); // the row can now show its icon, which only exists once the emote is published
+                });
+    }
+
+    private enum Action {
+        SEARCH, PREV, NEXT
+    }
+
+    public static final class Data {
+        static final String KEY_ACTION = "Action";
+        static final String KEY_EMOTE = "Emote";
+        /** The leading '@' makes the client resolve the value as a selector when the event fires. */
+        static final String KEY_QUERY = "@Query";
+
+        static final BuilderCodec<Data> CODEC = BuilderCodec.builder(Data.class, Data::new)
+                .addField(new KeyedCodec<>(KEY_ACTION, Codec.STRING), (d, v) -> d.action = v, d -> d.action)
+                .addField(new KeyedCodec<>(KEY_EMOTE, Codec.STRING), (d, v) -> d.emote = v, d -> d.emote)
+                .addField(new KeyedCodec<>(KEY_QUERY, Codec.STRING), (d, v) -> d.query = v, d -> d.query)
+                .build();
+
+        private String action;
+        private String emote;
+        private String query;
+    }
+}

--- a/hytale/src/main/java/io/github/kosmx/emotes/hytale/ui/McComponents.java
+++ b/hytale/src/main/java/io/github/kosmx/emotes/hytale/ui/McComponents.java
@@ -1,0 +1,147 @@
+package io.github.kosmx.emotes.hytale.ui;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.hypixel.hytale.server.core.Message;
+
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Converts Minecraft text components into Hytale {@link Message}s.
+ * <p>
+ * The emote library speaks Minecraft's component JSON — the Minecraft client feeds {@code GameEmoteInfo}'s name,
+ * description and author straight through {@code Component.Serializer}. Handing those strings to a Hytale label would
+ * show raw JSON, so the tree is walked here instead. The two models line up closely: text and translation nodes,
+ * children, and the colour/bold/italic styling all have direct counterparts.
+ */
+public final class McComponents {
+    private McComponents() {
+    }
+
+    /** Minecraft's sixteen legacy colour names; anything else is already a {@code #rrggbb} literal. */
+    private static final Map<String, String> COLORS = Map.ofEntries(
+            Map.entry("black", "#000000"), Map.entry("dark_blue", "#0000aa"),
+            Map.entry("dark_green", "#00aa00"), Map.entry("dark_aqua", "#00aaaa"),
+            Map.entry("dark_red", "#aa0000"), Map.entry("dark_purple", "#aa00aa"),
+            Map.entry("gold", "#ffaa00"), Map.entry("gray", "#aaaaaa"),
+            Map.entry("dark_gray", "#555555"), Map.entry("blue", "#5555ff"),
+            Map.entry("green", "#55ff55"), Map.entry("aqua", "#55ffff"),
+            Map.entry("red", "#ff5555"), Map.entry("light_purple", "#ff55ff"),
+            Map.entry("yellow", "#ffff55"), Map.entry("white", "#ffffff")
+    );
+
+    /**
+     * @param json a serialized Minecraft component, which may also be a bare string
+     * @param language the viewing player's language, as {@code PlayerRef#getLanguage} reports it
+     * @return the equivalent Hytale message, or a raw message holding the input if it does not parse
+     */
+    public static Message toMessage(String json, String language) {
+        if (json == null || json.isEmpty()) {
+            return Message.raw("");
+        }
+
+        try {
+            return convert(JsonParser.parseString(json), normalize(language));
+        } catch (Exception e) {
+            return Message.raw(json); // not a component after all - show it as the plain text it presumably is
+        }
+    }
+
+    /** Locale tags are compared as Minecraft writes them: lower case with an underscore, e.g. {@code en_us}. */
+    private static String normalize(String language) {
+        return language == null ? "" : language.toLowerCase(Locale.ROOT).replace('-', '_');
+    }
+
+    private static Message convert(JsonElement element, String language) {
+        if (element.isJsonPrimitive()) {
+            return Message.raw(element.getAsString());
+        }
+
+        if (element.isJsonArray()) {
+            JsonArray array = element.getAsJsonArray();
+            if (array.isEmpty()) {
+                return Message.raw("");
+            }
+
+            // A component array is its first element with the rest appended, which is exactly what insert does.
+            Message message = convert(array.get(0), language);
+            for (int i = 1; i < array.size(); i++) {
+                message.insert(convert(array.get(i), language));
+            }
+            return message;
+        }
+
+        JsonObject object = element.getAsJsonObject();
+        Message message = base(object, language);
+
+        if (object.has("color")) {
+            String color = object.get("color").getAsString();
+            message.color(COLORS.getOrDefault(color.toLowerCase(Locale.ROOT), color));
+        }
+        if (object.has("bold")) {
+            message.bold(object.get("bold").getAsBoolean());
+        }
+        if (object.has("italic")) {
+            message.italic(object.get("italic").getAsBoolean());
+        }
+
+        if (object.has("extra")) {
+            for (JsonElement child : object.getAsJsonArray("extra")) {
+                message.insert(convert(child, language));
+            }
+        }
+        return message;
+    }
+
+    private static Message base(JsonObject object, String language) {
+        if (object.has("text")) {
+            return Message.raw(object.get("text").getAsString());
+        }
+
+        if (object.has("translate")) {
+            String fallback = fallback(object, language);
+            if (fallback != null) {
+                // Prefer the fallback outright. A Minecraft translation key means nothing to a Hytale client, so the
+                // localized literal the library ships alongside it is the only thing that can actually be displayed.
+                return Message.raw(fallback);
+            }
+
+            String key = object.get("translate").getAsString();
+            Message message = Message.translation(key);
+
+            // Minecraft substitutes positionally, Hytale by name. Numbered names keep the arguments addressable, so a
+            // Hytale-side .lang can render them; an untranslated key at least still carries its arguments.
+            if (object.has("with")) {
+                JsonArray with = object.getAsJsonArray("with");
+                for (int i = 0; i < with.size(); i++) {
+                    message.param(String.valueOf(i), convert(with.get(i), language));
+                }
+            }
+            return message;
+        }
+
+        return Message.raw("");
+    }
+
+    /**
+     * Picks the localized literal for a translation node.
+     * <p>
+     * Vanilla Minecraft allows a single {@code fallback}; the emote library instead ships a {@code fallbacks} map of
+     * locale to text, which on Minecraft needs the TranslationFallbacks mod because components resolve client-side.
+     * Here no such mod is needed: pages are built per player on the server, so the viewer's own language picks the
+     * entry directly, with the vanilla single fallback as the last resort.
+     */
+    private static String fallback(JsonObject object, String language) {
+        if (object.get("fallbacks") instanceof JsonObject fallbacks) {
+            JsonElement localized = fallbacks.get(language);
+            if (localized != null && localized.isJsonPrimitive()) {
+                return localized.getAsString();
+            }
+        }
+
+        return object.has("fallback") ? object.get("fallback").getAsString() : null;
+    }
+}

--- a/hytale/src/main/resources/Common/UI/Custom/Pages/Emotecraft/EmoteList.ui
+++ b/hytale/src/main/resources/Common/UI/Custom/Pages/Emotecraft/EmoteList.ui
@@ -1,0 +1,71 @@
+$C = "../../Common.ui";
+
+$C.@PageOverlay {
+  Anchor: (Top: 130);
+}
+
+$C.@Container {
+  Anchor: (Width: 600, Height: 700);
+
+  #Title {
+    $C.@Title {
+      @Text = %emotecraft.library.title;
+    }
+  }
+
+  #Content {
+    LayoutMode: Top;
+
+    Group {
+      LayoutMode: Left;
+      Anchor: (Bottom: 10, Height: $C.@DropdownBoxHeight);
+
+      $C.@TextField #SearchInput {
+        @Anchor = (Left: 0, Right: 10);
+        FlexWeight: 1;
+        PlaceholderText: %server.customUI.searchPlaceholder;
+      }
+
+      $C.@TextButton #Search {
+        Text: %emotecraft.library.search.button;
+      }
+    }
+
+    Group #List {
+      FlexWeight: 1;
+      Anchor: (Bottom: 15);
+      LayoutMode: TopScrolling;
+      ScrollbarStyle: $C.@DefaultScrollbarStyle;
+    }
+
+    Label #Status {
+      Padding: 8;
+      Style: (
+        FontSize: 14,
+        HorizontalAlignment: Center,
+        TextColor: #94969a
+      );
+      Text: " ";
+    }
+
+    Group {
+      LayoutMode: Left;
+      Anchor: (Top: 15);
+
+      $C.@TextButton #Prev {
+        @Anchor = (Right: 10);
+        Text: %emotecraft.library.prev;
+        FlexWeight: 1;
+        Disabled: true;
+      }
+
+      $C.@TextButton #Next {
+        Text: %emotecraft.library.next;
+        FlexWeight: 1;
+        Disabled: true;
+      }
+    }
+  }
+}
+
+$C.@BackButton {}

--- a/hytale/src/main/resources/Common/UI/Custom/Pages/Emotecraft/EmoteRow.ui
+++ b/hytale/src/main/resources/Common/UI/Custom/Pages/Emotecraft/EmoteRow.ui
@@ -1,0 +1,39 @@
+Button #Button {
+  Padding: (Full: 6);
+  LayoutMode: Left;
+  Style: (
+    Hovered: (
+      Background: #000000(0.2),
+    )
+  );
+
+  AssetImage #Icon {
+    Anchor: (Width: 32, Height: 32, Right: 8);
+  }
+
+  Group {
+    LayoutMode: Top;
+    FlexWeight: 1;
+
+    Group {
+      LayoutMode: Left;
+
+      Label #Name {
+        Style: (RenderBold: true);
+        FlexWeight: 1;
+      }
+
+      Label #Author {
+        Style: (TextColor: #ffffff(0.2), RenderItalics: true);
+      }
+    }
+
+    Label #Description {
+      Style: (FontSize: 12, TextColor: #94969a);
+    }
+
+    Label #Tags {
+      Style: (FontSize: 11, TextColor: #6a7d8f, RenderItalics: true);
+    }
+  }
+}

--- a/hytale/src/main/resources/META-INF/services/io.github.kosmx.emotes.server.services.InstanceService
+++ b/hytale/src/main/resources/META-INF/services/io.github.kosmx.emotes.server.services.InstanceService
@@ -1,0 +1,1 @@
+io.github.kosmx.emotes.hytale.services.HytaleInstanceService

--- a/hytale/src/main/resources/Server/Languages/en-US/emotecraft/commands.lang
+++ b/hytale/src/main/resources/Server/Languages/en-US/emotecraft/commands.lang
@@ -1,0 +1,1 @@
+emotecraft.desc = Browse your Emotecraft emote library

--- a/hytale/src/main/resources/Server/Languages/en-US/emotecraft/library.lang
+++ b/hytale/src/main/resources/Server/Languages/en-US/emotecraft/library.lang
@@ -1,0 +1,6 @@
+# The search field's placeholder reuses Hytale's own server.customUI.searchPlaceholder; only the strings with no
+# vanilla equivalent are defined here.
+title = Emote Library
+search.button = Search
+prev = Previous
+next = Next

--- a/hytale/src/main/resources/manifest.json
+++ b/hytale/src/main/resources/manifest.json
@@ -1,0 +1,20 @@
+{
+  "Group": "io.github.kosmx.emotes",
+  "Name": "Emotecraft",
+  "Version": "${version}",
+  "Description": "${description}",
+  "Authors": [
+    {
+      "Name": "KosmX",
+      "Email": "kosmx.mc@gmail.com"
+    },
+    {
+      "Name": "dima_dencep",
+      "Email": "dima_dencep@redlance.org"
+    }
+  ],
+  "Website": "https://github.com/KosmX/emotes",
+  "Main": "io.github.kosmx.emotes.hytale.EmotecraftPlugin",
+  "ServerVersion": ">=0.5.7",
+  "IncludesAssetPack": true
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,3 +22,6 @@ include("paper")
 
 // Geyser ext
 include("geyser")
+
+// Hytale server mod
+include("hytale")


### PR DESCRIPTION
Brings Emotecraft emotes to stock Hytale clients. The animation engine is run over an emote, the resulting pose is sampled into a .blockyanim clip, and that clip plus an icon are registered as a native emote asset at runtime - so an emote becomes playable without a restart, a pack rebuild or a client mod, and shows up in the client's own emote wheel.

Emotes come from the built-in set and from the cloud library, browsed per player through /emotecraft. A body is downloaded only when somebody picks that emote, and every baked clip is cached on disk, so a restart costs no downloads and the library's quota is spent once per emote ever.

Blobs are delivered per client rather than broadcast: icons when a client reports itself ready, clips to whoever can see the performer. What is playing is recorded on the performing entity as well, so a player who comes into range part-way through is shown it too.

Nothing here has run against a real client yet. The retargeting constants, the page markup and the active-animation path are all unverified; see agents/hytale.md for what to expect to calibrate.